### PR TITLE
Update lint.go to add UTF8 as initialism

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -421,8 +421,8 @@ func lintName(name string) (should string) {
 // Only add entries that are highly unlikely to be non-initialisms.
 // For instance, "ID" is fine (Freudian code is rare), but "AND" is not.
 var commonInitialisms = map[string]bool{
-	"ASCII": true,
 	"API":   true,
+	"ASCII": true,
 	"EOF":   true,
 	"HTML":  true,
 	"HTTP":  true,
@@ -430,9 +430,9 @@ var commonInitialisms = map[string]bool{
 	"IP":    true,
 	"JSON":  true,
 	"RPC":   true,
-	"UTF8":  true,
 	"UID":   true,
 	"URL":   true,
+	"UTF8":  true,
 	"XML":   true,
 }
 


### PR DESCRIPTION
I think adding UTF8 would be good. ASCII is also in there and I think UTF8 should be either lowercase for a package name as in `unicode/utf8` or uppercase for a name as in `ErrInvalidUTF8`. (src: http://golang.org/src/pkg/regexp/syntax/parse.go#L40)

Some stats of the usage of 'UTF8' versus 'Utf8' in the stdlib:
http://golang.org/search?q=UTF8
http://golang.org/search?q=Utf8
