### PR TITLE
Exits with status 1 if golint fails while reading or parsing

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -20,6 +20,7 @@ import (
 )
 
 var minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
+var lintingError = false
 
 func main() {
 	flag.Parse()
@@ -32,6 +33,11 @@ func main() {
 			lintFile(filename)
 		}
 	}
+
+	// exit with error code if there was trouble reading or parsing a file.
+	if lintingError {
+		os.Exit(1)
+	}
 }
 
 func isDir(filename string) bool {
@@ -43,6 +49,7 @@ func lintFile(filename string) {
 	src, err := ioutil.ReadFile(filename)
 	if err != nil {
 		log.Printf("Failed reading %v: %v", filename, err)
+		lintingError = true
 		return
 	}
 
@@ -50,6 +57,7 @@ func lintFile(filename string) {
 	ps, err := l.Lint(filename, src)
 	if err != nil {
 		log.Printf("Failed parsing %v: %v", filename, err)
+		lintingError = true
 		return
 	}
 	for _, p := range ps {


### PR DESCRIPTION
Exit status behavior should be reasonable, as per previous discussion about exit codes.
