### PR TITLE
Adding STDIN support

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -59,7 +59,7 @@ func lintStdin() {
 		return
 	}
 
-	lintSrc("stdin", bytes)
+	lintSrc("(standard input)", bytes)
 }
 
 func lintSrc(filename string, src []byte) {


### PR DESCRIPTION
I noticed the TODO. :)

This reads from `stdin` and behaves similarly to `grep -nr`, reporting the filename as `(standard input)`
