### PR TITLE
Add autoload cookie for lazy loading

### DIFF
--- a/misc/emacs/golint.el
+++ b/misc/emacs/golint.el
@@ -39,6 +39,7 @@
        'golint-process-setup)
 )
 
+;;;###autoload
 (defun golint ()
   "Run golint on the current file and populate the fix list. Pressing C-x ` will jump directly to the line in your code which caused the first message."
   (interactive)


### PR DESCRIPTION
This patch makes lazy loading. We can load lazy `golint.el` until `M-x golint` executed
if we install `golint.el` with `package.el` or `el-get`.

Please see this patch.
