### PR TITLE
error output now compatible with vim quickfix

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,14 +40,14 @@ func isDir(filename string) bool {
 func lintFile(filename string) {
 	src, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Printf("Failed reading %v: %v", filename, err)
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
 	l := new(lint.Linter)
 	ps, err := l.Lint(filename, src)
 	if err != nil {
-		log.Printf("Failed parsing %v: %v", filename, err)
+		fmt.Fprintf(os.Stderr, "%v:%v\n", filename, err)
 		return
 	}
 	for _, p := range ps {


### PR DESCRIPTION
Prior to this change, read errors and parse errors would cause vim quickfix to
open new buffers with meaningless paths. For logged output, vim would open a new
buffer with the timestamp as a name.

This change makes some assumptions that are true today:
- Errors from ioutil.ReadFile are user-readable and meaningful alone.
  
    e.g. `open example.go: no such file or directory`
- Errors from parsing concatenate with the filename to produce quickfix format.
  
    e.g. `example.go:8:1: expected declaration, found '}'`

With this change, the suggested autosave behavior from the README is usable.
