### PR TITLE
Let Golint ignore a function whose name starts "Benchmark" when it checks function declarations.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -317,7 +317,7 @@ func (f *file) lintNames() {
 				}
 			}
 		case *ast.FuncDecl:
-			if f.isTest() && (strings.HasPrefix(v.Name.Name, "Example") || strings.HasPrefix(v.Name.Name, "Test")) {
+			if f.isTest() && (strings.HasPrefix(v.Name.Name, "Example") || strings.HasPrefix(v.Name.Name, "Test") || strings.HasPrefix(v.Name.Name, "Benchmark")) {
 				return true
 			}
 			check(v.Name, "func")


### PR DESCRIPTION
Let Golint ignore a function whose name starts "Benchmark" when it checks function declarations.

This fix allows us to name a function such as "BenchmarkT_M".

http://golang.org/cmd/go/#hdr-Description_of_testing_functions
