### PR TITLE
don't crash when the problematic file isn't there

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -173,7 +173,10 @@ func (p *pkg) errorfAt(pos token.Position, confidence float64, args ...interface
 		Confidence: confidence,
 	}
 	if pos.Filename != "" {
-		problem.LineText = srcLine(p.files[pos.Filename].src, pos)
+		file, fileExists := p.files[pos.Filename]
+		if fileExists {
+			problem.LineText = srcLine(file.src, pos)
+		}
 	}
 
 argLoop:


### PR DESCRIPTION
in practice this happens with generated source files that take
advantage of the //line filename:line syntax to register
alternative file and line number information
See: http://golang.org/pkg/go/token/#File.AddLineInfo

one tool that produces such comments is go yacc
golint found a problem, the //line comments pointed
to my .y file, and the .y file wasn't in the files map
which leads to a panic

this commit isn't perfect, as the error message printed
is somewhat confusing as it references the .y file
but shows code from the generated .go file
