### PR TITLE
allow one underscore between digits

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -613,6 +613,12 @@ func lintName(name string) (should string) {
 			for i+n+1 < len(runes) && runes[i+n+1] == '_' {
 				n++
 			}
+
+			// Leave at most one underscore if the underscore is between two digits
+			if i+n+1 < len(runes) && unicode.IsDigit(runes[i]) && unicode.IsDigit(runes[i+n+1]) {
+				n--
+			}
+
 			copy(runes[i+1:], runes[i+n+1:])
 			runes = runes[:len(runes)-n]
 		} else if unicode.IsLower(runes[i]) && !unicode.IsLower(runes[i+1]) {

--- a/lint_test.go
+++ b/lint_test.go
@@ -187,6 +187,10 @@ func TestLintName(t *testing.T) {
 		{"a__b", "aB"},
 		{"a___b", "aB"},
 		{"Rpc1150", "RPC1150"},
+		{"case3_1", "case3_1"},
+		{"case3__1", "case3_1"},
+		{"IEEE802_16bit", "IEEE802_16bit"},
+		{"IEEE802_16Bit", "IEEE802_16Bit"},
 	}
 	for _, test := range tests {
 		got := lintName(test.name)

--- a/testdata/names.go
+++ b/testdata/names.go
@@ -71,3 +71,17 @@ type i interface {
 
 	F(foo_bar int) // MATCH /foo_bar.*fooBar/
 }
+
+// All okay; underscore between digits
+const case1_1 = 1
+
+type case2_1 struct {
+	case2_2 int
+}
+
+func case3_1(case3_2 int) (case3_3 string) {
+	case3_4 := 4
+	_ = case3_4
+
+	return ""
+}


### PR DESCRIPTION
Fixes #47, which makes sense to me. I am wondering if there is a rule for lower/upper case after digits? I did not find any thread, spec nor code convention about digits in camelCase. The closest conversation was https://programmers.stackexchange.com/questions/140699/how-to-camel-case-where-consecutive-words-have-numbers where even Rob Pike is quoted.
