### PR TITLE
add configuration for travisCI and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+install:
+  - go get -t -v ./...
+
+script:
+  - go test -v ./...


### PR DESCRIPTION
This adds support for TravisCI [https://travis-ci.org/] and Coveralls [coveralls.io] to the project which is quite common on Github. Every commit and PR will run through the CI and will be therefore tested automatically. The status of every run will be shown in the Github UI. Coverage reports for every project commit (NOT for PR commits) will be send to Coveralls, so keeping track of the project's coverage is possible.

The code coverage part in the script uses ginkgo and gover to allow recursive coverage report. This is a workaround until -coverprofile can be done on multiple packages. I know that the project has currently only one package but this is future proof and does not hurt since it is automated.

Since I am not the maintainer of the project @dsymonds you have to enable support for the project on TravisCI and Coveralls and add the secure token for Coveralls (you can also post it here and I include it in the commit) http://docs.travis-ci.com/user/encryption-keys/