### PR TITLE
API change for golang.org/x/tools/go/types

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1398,11 +1398,11 @@ func (f *file) isUntypedConst(expr ast.Expr, scope *types.Scope) (defType string
 
 	// Re-evaluate expr outside of its context to see if it's untyped.
 	// (An expr evaluated within, for example, an assignment context will get the type of the LHS.)
-	typ, _, err := types.EvalNode(f.fset, expr, f.pkg.typesPkg, scope)
+	tv, err := types.EvalNode(f.fset, expr, f.pkg.typesPkg, scope)
 	if err != nil {
 		return "", false
 	}
-	if b, ok := typ.(*types.Basic); ok {
+	if b, ok := tv.Type.(*types.Basic); ok {
 		if dt, ok := basicTypeKinds[b.Kind()]; ok {
 			return dt, true
 		}

--- a/lint_test.go
+++ b/lint_test.go
@@ -230,13 +230,13 @@ func TestExportedType(t *testing.T) {
 		}
 		// Use the first child scope of the package, which will be the file scope.
 		scope := pkg.Scope().Child(0)
-		typ, _, err := types.Eval(test.typString, pkg, scope)
+		tv, err := types.Eval(test.typString, pkg, scope)
 		if err != nil {
 			t.Errorf("types.Eval(%q): %v", test.typString, err)
 			continue
 		}
-		if got := exportedType(typ); got != test.exp {
-			t.Errorf("exportedType(%v) = %t, want %t", typ, got, test.exp)
+		if got := exportedType(tv.Type); got != test.exp {
+			t.Errorf("exportedType(%v) = %t, want %t", tv.Type, got, test.exp)
 		}
 	}
 }


### PR DESCRIPTION
The API for types.Eval and types.EvalNode have changed https://github.com/golang/tools/commit/6370cd3a8e29686c28bf339debaf967f046b8d46
They now return both type and value in one object.
