### PR TITLE
Add lint check for errors compared to strings.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -177,6 +177,7 @@ func (f *file) lint() {
 	f.lintErrorf()
 	f.lintErrors()
 	f.lintErrorStrings()
+	f.lintErrorComparisons()
 	f.lintReceiverNames()
 	f.lintIncDec()
 	f.lintMake()
@@ -1122,6 +1123,32 @@ func (f *file) lintErrorStrings() {
 			conf = 0.6
 		}
 		f.errorf(str, conf, link(styleGuideBase+"#error-strings"), category("errors"), msg)
+		return true
+	})
+}
+
+// lintErrorComparisons examines uses of errors. It complains if errors are compared to strings.
+func (f *file) lintErrorComparisons() {
+	f.walk(func(n ast.Node) bool {
+		ce, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isPkgDot(ce.Fun, "strings", "Contains") {
+			return true
+		}
+		if len(ce.Args) < 2 {
+			return true
+		}
+		src, ok := ce.Args[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selSrc, ok := src.Fun.(*ast.SelectorExpr)
+		if !ok || !isIdent(selSrc.Sel, "Error") {
+			return true
+		}
+		f.errorf(n, 0.9, category("errors"), `error should not be compared to string`)
 		return true
 	})
 }

--- a/testdata/error-comparison.go
+++ b/testdata/error-comparison.go
@@ -1,0 +1,12 @@
+// Test for errors compared to strings.
+
+// Package foo ...
+package foo
+
+import "strings"
+
+func f(err error) bool {
+	if strings.Contains(err.Error(), "a string") { // MATCH /should not be compared to string/
+		return true
+	}
+}


### PR DESCRIPTION
There may be other string comparison patterns to catch in this lint
check, but I already have several hundred matching examples for this.