### PR TITLE
golint should always run with the latest dependencies

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Golint is a linter for Go source code.
 
 To install, run
-  go get github.com/golang/lint/golint
+  go get -u github.com/golang/lint/golint
 
 Invoke golint with one or more filenames, a directory, or a package named
 by its import path. Golint uses the same import path syntax as the go


### PR DESCRIPTION
Maybe this will help with the out of date packages. It fetches the following packages anew.

```
golang.org/x/tools/go/exact
golang.org/x/tools/go/ast/astutil
golang.org/x/tools/go/types
golang.org/x/tools/go/gcimporter
github.com/golang/lint
```