### PR TITLE
fix assignment mismatch

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1429,11 +1429,11 @@ func (f *file) isUntypedConst(expr ast.Expr, scope *types.Scope) (defType string
 
 	// Re-evaluate expr outside of its context to see if it's untyped.
 	// (An expr evaluated within, for example, an assignment context will get the type of the LHS.)
-	tv, err := types.EvalNode(f.fset, expr, f.pkg.typesPkg, scope)
+	tv, _, err := types.EvalNode(f.fset, expr, f.pkg.typesPkg, scope)
 	if err != nil {
 		return "", false
 	}
-	if b, ok := tv.Type.(*types.Basic); ok {
+	if b, ok := tv.(*types.Basic); ok {
 		if dt, ok := basicTypeKinds[b.Kind()]; ok {
 			return dt, true
 		}


### PR DESCRIPTION
I didn't see an issue for it, so maybe it's just some weird dependency state that I have but this fixes:

```
lint/lint.go:1432: assignment count mismatch: 2 = 3
```