### PR TITLE
Improve Structure and Formatting of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,24 @@ Golint is a linter for Go source code.
 
 [![Build Status](https://travis-ci.org/golang/lint.svg?branch=master)](https://travis-ci.org/golang/lint)
 
-To install, run
-  go get -u github.com/golang/lint/golint
+## Installation
+  
+    go get -u github.com/golang/lint/golint
 
-Invoke golint with one or more filenames, a directory, or a package named
-by its import path. Golint uses the same import path syntax as the go
-command (https://golang.org/cmd/go/#hdr-Import_path_syntax) and therefore
-also supports relative import paths like "./...". Additionally the "..."
+## Usage
+
+Invoke `golint` with one or more filenames, a directory, or a package named
+by its import path. Golint uses the same
+[import path syntax](https://golang.org/cmd/go/#hdr-Import_path_syntax) as
+the `go` command and therefore
+also supports relative import paths like `./...`. Additionally the `...`
 wildcard can be used as suffix on relative and absolute file paths to recurse
 into them.
 
 The output of this tool is a list of suggestions in Vim quickfix format,
 which is accepted by lots of different editors.
+
+## Purpose
 
 Golint differs from gofmt. Gofmt reformats Go source code, whereas
 golint prints out style mistakes.
@@ -31,37 +37,41 @@ In short, this tool is not, and will never be, trustworthy enough for its
 suggestions to be enforced automatically, for example as part of a build process.
 
 If you find an established style that is frequently violated, and which
-you think golint could statically check, file an issue at
-  https://github.com/golang/lint/issues
+you think golint could statically check,
+[file an issue](https://github.com/golang/lint/issues).
 
+## Contributions
 
-Contributions
--------------
 Contributions to this project are welcome, though please send mail before
 starting work on anything major. Contributors retain their copyright, so we
-need you to fill out a short form before we can accept your contribution:
-  https://developers.google.com/open-source/cla/individual
+need you to fill out
+[a short form](https://developers.google.com/open-source/cla/individual)
+before we can accept your contribution.
 
+## Vim
 
-Vim
----
 Add this to your ~/.vimrc:
-  set rtp+=$GOPATH/src/github.com/golang/lint/misc/vim
-If you have multiple entries in your GOPATH, replace $GOPATH with the right value.
 
-Running :Lint will run golint on the current file and populate the quickfix list.
+    set rtp+=$GOPATH/src/github.com/golang/lint/misc/vim
 
-Optionally, add this to your ~/.vimrc to automatically run golint on :w
-  autocmd BufWritePost,FileWritePost *.go execute 'Lint' | cwindow
+If you have multiple entries in your GOPATH, replace `$GOPATH` with the right value.
+
+Running `:Lint` will run golint on the current file and populate the quickfix list.
+
+Optionally, add this to your `~/.vimrc` to automatically run `golint` on `:w`
+  
+    autocmd BufWritePost,FileWritePost *.go execute 'Lint' | cwindow
 
 
-Emacs
------
-Add this to your .emacs file:
-  (add-to-list 'load-path (concat (getenv "GOPATH")  "/src/github.com/golang/lint/misc/emacs"))
-  (require 'golint)
-If you have multiple entries in your GOPATH, replace $GOPATH with the right value.
+## Emacs
+
+Add this to your `.emacs` file:
+
+    (add-to-list 'load-path (concat (getenv "GOPATH")  "/src/github.com/golang/lint/misc/emacs"))
+    (require 'golint)
+
+If you have multiple entries in your GOPATH, replace `$GOPATH` with the right value.
 
 Running M-x golint will run golint on the current file.
-For more usage, see Compilation-Mode:
-  http://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html
+
+For more usage, see [Compilation-Mode](http://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html).


### PR DESCRIPTION
* The installation instructions were too easy to miss (I missed them)
* It’s a Markdown file but wasn’t using Markdown markup.