### PR TITLE
Implemented detection of shadowing variables/functions

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -20,6 +20,7 @@ import (
 )
 
 var minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
+var shadowIgnore = flag.String("shadow_ignore", "*", "disables warning about shadowing of certain variables according to a RegExp. \"^.\" warns on everything.")
 
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
@@ -80,6 +81,7 @@ func lintFiles(filenames ...string) {
 	}
 
 	l := new(lint.Linter)
+	l.ShadowIgnore = *shadowIgnore
 	ps, err := l.LintFiles(files)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/lint_test.go
+++ b/lint_test.go
@@ -28,6 +28,7 @@ var lintMatch = flag.String("lint.match", "", "restrict testdata matches to this
 
 func TestAll(t *testing.T) {
 	l := new(Linter)
+	l.ShadowIgnore = "err"
 	rx, err := regexp.Compile(*lintMatch)
 	if err != nil {
 		t.Fatalf("Bad -lint.match value %q: %v", *lintMatch, err)

--- a/testdata/else.go
+++ b/testdata/else.go
@@ -5,7 +5,7 @@ package pkg
 
 import "log"
 
-func f(x int) bool {
+func g(x int) bool {
 	if x > 0 {
 		return true
 	} else { // MATCH /if.*return.*else.*outdent/
@@ -14,7 +14,7 @@ func f(x int) bool {
 	return false
 }
 
-func g(f func() bool) string {
+func h(f func() bool) string {
 	if ok := f(); ok {
 		return "it's okay"
 	} else { // MATCH /if.*return.*else.*outdent.*short.*var.*declaration/

--- a/testdata/shadow.go
+++ b/testdata/shadow.go
@@ -1,0 +1,41 @@
+// Test for shadowing variables
+
+// Package foo ...
+package foo
+
+func f(x int) bool {
+	y := 7
+	err := "test"
+	if x > 10 {
+		x := 7 // MATCH /shadowing variable - x/
+		y := 7 // MATCH /shadowing variable - y/
+		if true {
+			x = 7 // Fine
+		}
+
+		err := "notetst" // Fine since err is in ignore list
+		return true
+	}
+	func(x int) { // MATCH /shadowing variable - x/
+		return
+	}(10)
+	return false
+}
+
+var a int
+
+func g(a int) int { // MATCH /shadowing variable - a/
+	return a
+}
+func h() (a int) { // MATCH /shadowing variable - a/
+	return a
+}
+func i(b int) (c int) {
+	if true {
+		b := 1 // MATCH /shadowing variable - b/
+		c := 1 // MATCH /shadowing variable - c/
+		_ = b
+		_ = c
+	}
+	return
+}

--- a/testdata/shadow.go
+++ b/testdata/shadow.go
@@ -3,9 +3,12 @@
 // Package foo ...
 package foo
 
+import "math"
+
 func f(x int) bool {
-	y := 7
+	y := math.Sin(5)
 	err := "test"
+	math := "duck" // MATCH /shadowing variable - math/
 	if x > 10 {
 		x := 7 // MATCH /shadowing variable - x/
 		y := 7 // MATCH /shadowing variable - y/


### PR DESCRIPTION
Hey, I implemented detection of shadowed variables.

I know it's been discussed before with issue #27 but it hasn't been addressed since then and seems like a fairly useful tool. Many Linters implement this (ex jslint) and I figure it should be an option in Go.

Since it's a controversial issue, I implemented a command line flag `-shadow_ignore="*"` with everything ignored by default. It's blacklisted by RegExp with the thought being that common Go style often uses the same variable for errors `err` thus using the RegExp you can ignore them just by passing `-shadow_ignore="err"`.

I'd love to hear your thoughts on it.