### PR TITLE
Add linter rule to enforce function docs to end with periods

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -807,6 +807,9 @@ func (f *file) lintFuncDoc(fn *ast.FuncDecl) {
 	if !strings.HasPrefix(s, prefix) {
 		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "%s..."`, kind, name, prefix)
 	}
+	if !strings.HasSuffix(strings.TrimSpace(s), ".") {
+		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comment-sentences"), `comment on exported %s %s should end with a period`, kind, name)
+	}
 }
 
 // lintValueSpecDoc examines package-global variables and constants.


### PR DESCRIPTION
I have an embarrassing tendency to forget the dots at the end of my sentences, I think it would be neat if the go linter would warn me about this before I show my code to other people.