### PR TITLE
Lint files that use cgo

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -114,6 +114,7 @@ func lintImportedPackage(pkg *build.Package, err error) {
 
 	var files []string
 	files = append(files, pkg.GoFiles...)
+	files = append(files, pkg.CgoFiles...)
 	files = append(files, pkg.TestGoFiles...)
 	if pkg.Dir != "." {
 		for i, f := range files {


### PR DESCRIPTION
go/build separates Go files into two categories (not counting test
files): pure Go files (GoFiles), and files that use cgo (CgoFiles).