### PR TITLE
Create lint checks for documentation examples.

### DIFF
--- a/lint_test.go
+++ b/lint_test.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/tools/go/types"
 )
 
-var lintMatch = flag.String("lint.match", "", "restrict testdata matches to this pattern")
+var lintMatch = flag.String("lint.match", "^*.go$", "restrict testdata matches to this pattern")
 
 func TestAll(t *testing.T) {
 	l := new(Linter)

--- a/testdata/5_test.go
+++ b/testdata/5_test.go
@@ -13,5 +13,8 @@ func TestSomething(t *testing.T) {
 func TestSomething_suffix(t *testing.T) {
 }
 
-func ExampleBuffer_reader() {
-}
+type Buffer struct{}
+
+func (Buffer) read() {}
+
+func ExampleBuffer_read() {}

--- a/testdata/divergentexamples_test.go
+++ b/testdata/divergentexamples_test.go
@@ -1,0 +1,38 @@
+// Test of examples with divergent packages.
+
+// Package bytes_test ...
+package bytes_test
+
+import "bytes"
+
+func Example() {} // ok because is package-level.
+
+func Example_suffix() // ok because refers to suffix annotation.
+
+func Example_BadSuffix() // MATCH /Example_BadSuffix has malformed example suffix: BadSuffix/
+
+func ExampleBuffer() // ok because refers to bytes.Buffer.
+
+func ExampleBuffer_Len() {} // ok because refers to known method.
+
+func ExampleBuffer_Clear() {} // MATCH /ExampleBuffer_Clear refers to unknown field or method: Buffer.Clear/
+
+func ExampleBuffer_suffix() {} // ok because refers to suffix annotation.
+
+func ExampleBuffer_Write_Bad() {} // MATCH /ExampleBuffer_Write_Bad has malformed example suffix: Bad/
+
+func ExampleBuffer_Write_suffix() {} // ok because refers to known method with valid suffix.
+
+func ExampleErrTooLarge() {} // ok because refers to bytes.ErrTooLarge.
+
+func ExampleBuffer_Reset() bool { return true } // MATCH /ExampleBuffer_Reset should return nothing/
+
+func ExampleBuffer_Grow(i int) {} // MATCH /ExampleBuffer_Grow should be niladic/
+
+// "Puffer" is German for "Buffer".
+
+func ExamplePuffer() // MATCH /ExamplePuffer refers to unknown identifier: Puffer/
+
+func ExamplePuffer_Len() // MATCH /ExamplePuffer_Len refers to unknown identifier: Puffer/
+
+func ExamplePuffer_suffix() // MATCH /ExamplePuffer_suffix refers to unknown identifier: Puffer/

--- a/testdata/examples_test.go
+++ b/testdata/examples_test.go
@@ -1,0 +1,49 @@
+// Test of examples.
+
+// Package examples ...
+package examples
+
+// Buf is a ...
+type Buf []byte
+
+// Append ...
+func (*Buf) Append([]byte) {}
+
+func (Buf) Reset() {}
+
+func (Buf) Len() int { return 0 }
+
+// DefaultBuf is a ...
+var DefaultBuf Buf
+
+func Example() {} // ok because is package-level.
+
+func Example_suffix() // ok because refers to suffix annotation.
+
+func Example_BadSuffix() // MATCH /Example_BadSuffix has malformed example suffix: BadSuffix/
+
+func ExampleBuf() // ok because refers to known top-level type.
+
+func ExampleBuf_Append() {} // ok because refers to known method.
+
+func ExampleBuf_Clear() {} // MATCH /ExampleBuf_Clear refers to unknown field or method: Buf.Clear/
+
+func ExampleBuf_suffix() {} // ok because refers to suffix annotation.
+
+func ExampleBuf_Append_Bad() {} // MATCH /ExampleBuf_Append_Bad has malformed example suffix: Bad/
+
+func ExampleBuf_Append_suffix() {} // ok because refers to known method with valid suffix.
+
+func ExampleDefaultBuf() {} // ok because refers to top-level identifier.
+
+func ExampleBuf_Reset() bool { return true } // MATCH /ExampleBuf_Reset should return nothing/
+
+func ExampleBuf_Len(i int) {} // MATCH /ExampleBuf_Len should be niladic/
+
+// "Puffer" is German for "Buffer".
+
+func ExamplePuffer() // MATCH /ExamplePuffer refers to unknown identifier: Puffer/
+
+func ExamplePuffer_Append() // MATCH /ExamplePuffer_Append refers to unknown identifier: Puffer/
+
+func ExamplePuffer_suffix() // MATCH /ExamplePuffer_suffix refers to unknown identifier: Puffer/


### PR DESCRIPTION
In spite of https://blog.golang.org/examples and
http://golang.org/pkg/testing/#pkg-examples, a number of internal Go
authors have found writing documentation examples to be problematic in
the sense that the syntax is error-prone due to loose coupling with
identifiers found in the source corpus.

This commit introduces a suite of validations for documentation
examples:

    Overall:
    - Correct suffices, if present
    - Niladic function argument and return signatures

    func Example() {}
    func ExampleF() {}
    - F exists
    func ExampleT() {}
    - T exists
    func ExampleT_M() {}
    - T exists
    - M exists within T

Further, if the example is in `package foo_test`, the linter attempts
to resolve the respective lookups in `package foo`, if `package foo`
exists (cf., `package stringutil_test`).

/CC: @dsymonds - we spoke about this out-of-band of GitHub.