### PR TITLE
Add //golint:ignore comment support to skip files.

### DIFF
--- a/testdata/names-ignore.go
+++ b/testdata/names-ignore.go
@@ -1,0 +1,10 @@
+// Test for golint:ignore
+// OK
+//golint:ignore
+
+// Package pkg shows golint:ignore comment parsing
+package pkg
+
+type caseunderscore struct {
+	Foo_ func()
+}


### PR DESCRIPTION
This can be useful in the case of generated files such as protoc-gen-go generated files.