### PR TITLE
Use go/loader and add build tags as arguments

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -11,10 +11,13 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
-	"io/ioutil"
+	"go/parser"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"golang.org/x/tools/go/loader"
 
 	"github.com/golang/lint"
 )
@@ -35,26 +38,57 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
+	conf := &loader.Config{
+		ParserMode: parser.ParseComments,
+	}
+
 	switch flag.NArg() {
 	case 0:
-		lintDir(".")
+		addDir(conf, ".")
 	case 1:
 		arg := flag.Arg(0)
 		if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-4]) {
 			for _, dirname := range allPackagesInFS(arg) {
-				lintDir(dirname)
+				addDir(conf, dirname)
 			}
 		} else if isDir(arg) {
-			lintDir(arg)
+			addDir(conf, arg)
 		} else if exists(arg) {
-			lintFiles(arg)
+			conf.CreateFromFilenames(".", arg)
 		} else {
 			for _, pkgname := range importPaths([]string{arg}) {
-				lintPackage(pkgname)
+				conf.ImportWithTests(pkgname)
 			}
 		}
 	default:
-		lintFiles(flag.Args()...)
+		conf.CreateFromFilenames(".", flag.Args()...)
+	}
+
+	prog, err := conf.Load()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	l := new(lint.Linter)
+	var ps []lint.Problem
+
+	for _, pkg := range prog.InitialPackages() {
+		pp, err := l.LintFiles(prog.Fset, pkg.Files)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			continue
+		}
+
+		ps = append(ps, pp...)
+	}
+
+	sort.Sort(lint.ByPosition(ps))
+
+	for _, p := range ps {
+		if p.Confidence >= *minConfidence {
+			fmt.Printf("%v: %s\n", p.Position, p.Text)
+		}
 	}
 }
 
@@ -68,41 +102,9 @@ func exists(filename string) bool {
 	return err == nil
 }
 
-func lintFiles(filenames ...string) {
-	files := make(map[string][]byte)
-	for _, filename := range filenames {
-		src, err := ioutil.ReadFile(filename)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			continue
-		}
-		files[filename] = src
-	}
-
-	l := new(lint.Linter)
-	ps, err := l.LintFiles(files)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		return
-	}
-	for _, p := range ps {
-		if p.Confidence >= *minConfidence {
-			fmt.Printf("%v: %s\n", p.Position, p.Text)
-		}
-	}
-}
-
-func lintDir(dirname string) {
+func addDir(conf *loader.Config, dirname string) {
+	// go/loader does currently not expose ImportDir
 	pkg, err := build.ImportDir(dirname, 0)
-	lintImportedPackage(pkg, err)
-}
-
-func lintPackage(pkgname string) {
-	pkg, err := build.Import(pkgname, ".", 0)
-	lintImportedPackage(pkg, err)
-}
-
-func lintImportedPackage(pkg *build.Package, err error) {
 	if err != nil {
 		if _, nogo := err.(*build.NoGoError); nogo {
 			// Don't complain if the failure is due to no Go source files.
@@ -114,14 +116,23 @@ func lintImportedPackage(pkg *build.Package, err error) {
 
 	var files []string
 	files = append(files, pkg.GoFiles...)
-	files = append(files, pkg.CgoFiles...)
 	files = append(files, pkg.TestGoFiles...)
-	if pkg.Dir != "." {
+
+	joinDirWithFilenames(dirname, files)
+
+	conf.CreateFromFilenames(".", files...)
+
+	if files := pkg.XTestGoFiles; len(files) != 0 {
+		joinDirWithFilenames(dirname, files)
+
+		conf.CreateFromFilenames(".", files...)
+	}
+}
+
+func joinDirWithFilenames(dir string, files []string) {
+	if dir != "." {
 		for i, f := range files {
-			files[i] = filepath.Join(pkg.Dir, f)
+			files[i] = filepath.Join(dir, f)
 		}
 	}
-	// TODO(dsymonds): Do foo_test too (pkg.XTestGoFiles)
-
-	lintFiles(files...)
 }

--- a/golint/stringsflag.go
+++ b/golint/stringsflag.go
@@ -1,0 +1,66 @@
+package main
+
+/*
+
+This code is copied from cmd/go/build.go and should in my opinion be part of the "flag" package...
+
+*/
+
+import (
+	"fmt"
+)
+
+type stringsFlag []string
+
+func (v *stringsFlag) Set(s string) error {
+	var err error
+	*v, err = splitQuotedFields(s)
+	if *v == nil {
+		*v = []string{}
+	}
+	return err
+}
+
+func splitQuotedFields(s string) ([]string, error) {
+	// Split fields allowing '' or "" around elements.
+	// Quotes further inside the string do not count.
+	var f []string
+	for len(s) > 0 {
+		for len(s) > 0 && isSpaceByte(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		// Accepted quoted string. No unescaping inside.
+		if s[0] == '"' || s[0] == '\'' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			f = append(f, s[:i])
+			s = s[i+1:]
+			continue
+		}
+		i := 0
+		for i < len(s) && !isSpaceByte(s[i]) {
+			i++
+		}
+		f = append(f, s[:i])
+		s = s[i:]
+	}
+	return f, nil
+}
+
+func (v *stringsFlag) String() string {
+	return "<stringsFlag>"
+}
+
+func isSpaceByte(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}

--- a/lint_test.go
+++ b/lint_test.go
@@ -57,7 +57,7 @@ func TestAll(t *testing.T) {
 			continue
 		}
 
-		ps, err := l.Lint(fi.Name(), src)
+		ps, err := l.Lint(path.Join(baseDir, fi.Name()), src)
 		if err != nil {
 			t.Errorf("Linting %s: %v", fi.Name(), err)
 			continue


### PR DESCRIPTION
This PR does two things
- Converts golint to use go/loader which solves the problem of loading _test and multiple packages if the CLI arguments are adapted. There is still one small problem left and that is that with *.go ist still not working on different packages. That could be easily done after this PR.
- Add build tags as an argument