### PR TITLE
Rewrite lintElses check to handle multiple else ifs

### DIFF
--- a/testdata/else.go
+++ b/testdata/else.go
@@ -5,6 +5,13 @@ package pkg
 
 import "log"
 
+func e(x int) bool {
+	if x > 0 {
+		return true
+	}
+	return false
+}
+
 func f(x int) bool {
 	if x > 0 {
 		return true
@@ -20,4 +27,48 @@ func g(f func() bool) string {
 	} else { // MATCH /if.*return.*else.*outdent.*short.*var.*declaration/
 		return "it's NOT okay!"
 	}
+}
+
+func h() bool {
+	if false {
+		return false
+	} else if false {
+		return false
+	} else {
+		return true
+	}
+}
+
+func i() bool {
+	if false {
+		return false
+	} else if false {
+		return false
+	} else if false {
+		return false
+	} else {
+		return true
+	}
+}
+
+func j() bool {
+	if false {
+	} else if false {
+	} else if false {
+		return false
+	} else {
+	}
+	return true
+}
+
+func k() bool {
+	if false {
+		return false
+	} else if false {
+		return false
+	} else if false {
+		return false
+	} else {
+	}
+	return true
 }


### PR DESCRIPTION
As suggested by @dsymonds this PR handles multiple else-ifs in lintElses. The suggestion for outdenting an else block is only shown if the if block has a return as last statement, no else-ifs and of course an else block.The PR also adds some test cases to make the behavior clearer.
