### PR TITLE
Find unnecessary uses of select

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -187,6 +187,7 @@ func (f *file) lint() {
 	f.lintErrorReturn()
 	f.lintUnexportedReturn()
 	f.lintTimeNames()
+	f.lintSingleCaseSelect()
 }
 
 type link string
@@ -1420,6 +1421,41 @@ func (f *file) lintTimeNames() {
 				continue
 			}
 			f.errorf(v, 0.9, category("time"), "var %s is of type %v; don't use unit-specific suffix %q", name.Name, origTyp, suffix)
+		}
+		return true
+	})
+}
+
+func (f *file) lintSingleCaseSelect() {
+	isSingleSelect := func(node ast.Node) bool {
+		v, ok := node.(*ast.SelectStmt)
+		if !ok {
+			return false
+		}
+		return len(v.Body.List) == 1
+	}
+
+	seen := map[ast.Node]struct{}{}
+	f.walk(func(node ast.Node) bool {
+		switch v := node.(type) {
+		case *ast.ForStmt:
+			if len(v.Body.List) != 1 {
+				return true
+			}
+			if !isSingleSelect(v.Body.List[0]) {
+				return true
+			}
+			seen[v.Body.List[0]] = struct{}{}
+			f.errorf(node, 1, category("range-loop"), "should use for range instead of for { select {} }")
+		case *ast.SelectStmt:
+			if _, ok := seen[v]; ok {
+				return true
+			}
+			if !isSingleSelect(v) {
+				return true
+			}
+			f.errorf(node, 1, category("FIXME"), "should use a simple channel send/receive instead of select with a single case")
+			return true
 		}
 		return true
 	})

--- a/testdata/names.go
+++ b/testdata/names.go
@@ -49,6 +49,7 @@ func f_it() { // MATCH /underscore.*func.*f_it/
 	select {
 	case qId := <-c: // MATCH /var.*qId.*qID/
 		_ = qId
+	default:
 	}
 }
 

--- a/testdata/single-case-select.go
+++ b/testdata/single-case-select.go
@@ -1,0 +1,46 @@
+// Package foo ...
+package foo
+
+var ch1, ch2 chan int
+
+func fn1() {
+	select { // MATCH /simple channel send/
+	case <-ch1:
+	}
+
+	select {
+	case <-ch1:
+	case <-ch2:
+	}
+
+	select {
+	case <-ch1:
+	default:
+	}
+}
+
+func fn2() {
+	for { // MATCH /range instead of for/
+		select {
+		case <-ch1:
+		}
+	}
+}
+
+func fn3() {
+	for {
+		select {
+		case <-ch1:
+		case <-ch2:
+		}
+	}
+}
+
+func fn4() {
+	for {
+		select { // MATCH /simple channel send/
+		case <-ch1:
+		}
+		break
+	}
+}


### PR DESCRIPTION
This PR proposes and implements the detection of the following two patterns

```
select {
case x := <-ch:
}

for {
  select {
    case x := <-ch:
  }
}
```

and suggests replacing them with `x := <-ch` and `for x := range ch`.

This check matches 129 times on a corpus of 10770 packages. No hits in the standard library.

I haven't yet come up with a suitable category name for one of the errorf calls.