### PR TITLE
Fix support for "std" import path

### DIFF
--- a/golint/import.go
+++ b/golint/import.go
@@ -24,7 +24,7 @@ var buildContext = build.Default
 
 var (
 	goroot       = filepath.Clean(runtime.GOROOT())
-	gorootSrcPkg = filepath.Join(goroot, "src/pkg")
+	gorootSrcPkg = filepath.Join(goroot, "src")
 )
 
 // importPathsNoDotExpansion returns the import paths to use for the given


### PR DESCRIPTION
Since Go 1.4, stdlib lives in GOROOT/src, not GOROOT/src/pkg. The wrong
gorootSrcPkg broke the "std" pattern.