### PR TITLE
Allow superficially-generic receiver names when appropriate.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1223,6 +1223,16 @@ var badReceiverNames = map[string]bool{
 	"self": true,
 }
 
+func okReceiverName(recv string) string {
+	var rs []rune
+	for i, r := range recv {
+		if i == 0 || unicode.IsUpper(r) {
+			rs = append(rs, unicode.ToLower(r))
+		}
+	}
+	return string(rs)
+}
+
 // lintReceiverNames examines receiver names. It complains about inconsistent
 // names used for the same type and names such as "this".
 func (f *file) lintReceiverNames() {
@@ -1242,11 +1252,11 @@ func (f *file) lintReceiverNames() {
 			f.errorf(n, 1, link(ref), category("naming"), `receiver name should not be an underscore`)
 			return true
 		}
-		if badReceiverNames[name] {
+		recv := receiverType(fn)
+		if badReceiverNames[name] && name != okReceiverName(recv) {
 			f.errorf(n, 1, link(ref), category("naming"), `receiver name should be a reflection of its identity; don't use generic names such as "me", "this", or "self"`)
 			return true
 		}
-		recv := receiverType(fn)
 		if prev, ok := typeReceiver[recv]; ok && prev != name {
 			f.errorf(n, 1, link(ref), category("naming"), "receiver name %s should be consistent with previous receiver name %s for %s", name, prev, recv)
 			return true

--- a/lint_test.go
+++ b/lint_test.go
@@ -288,3 +288,22 @@ func TestExportedType(t *testing.T) {
 		}
 	}
 }
+
+func TestOKReceiverName(t *testing.T) {
+	tests := []struct {
+		recv string
+		want string
+	}{
+		{"foo", "f"},
+		{"Bar", "b"},
+		{"TLA", "tla"},
+		{"MultiError", "me"},
+		{"SideEffectLoadFormatter", "self"},
+		{"totalHealthInformationSystem", "this"},
+	}
+	for _, test := range tests {
+		if got := okReceiverName(test.recv); got != test.want {
+			t.Errorf("okReceiverName(%q) == %q, want %q", test.recv, got, test.want)
+		}
+	}
+}

--- a/testdata/receiver-names.go
+++ b/testdata/receiver-names.go
@@ -39,3 +39,18 @@ func (bar) f6() {
 
 func (_ *bar) f7() { // MATCH /receiver name should not be an underscore/
 }
+
+type multiError struct{}
+
+func (me multiError) f8() {
+}
+
+type sideEffectLoadFormatter struct{}
+
+func (self sideEffectLoadFormatter) f9() {
+}
+
+type totalHealthInformationSystem struct{}
+
+func (this totalHealthInformationSystem) f10() {
+}


### PR DESCRIPTION
This PR permits normally-forbidden receiver names like `me`, `this`, and `self` where they are appropriate, for example:

```go
type MultiError []error

func (me MultiError) Error() string {
    // ...
}
```