### PR TITLE
Check for context.TODO() in functions that have a context.Context argument.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -187,6 +187,7 @@ func (f *file) lint() {
 	f.lintErrorReturn()
 	f.lintUnexportedReturn()
 	f.lintTimeNames()
+	f.lintContextTODO()
 }
 
 type link string
@@ -1434,6 +1435,71 @@ func (f *file) lintTimeNames() {
 		}
 		return true
 	})
+}
+
+var contextPackages = []string{
+	"context",
+	"golang.org/x/net/context",
+}
+
+// lintContextTODO examines context.TODO() calls and warns if the function has a
+// context.Context argument.
+func (f *file) lintContextTODO() {
+	for _, imp := range f.f.Imports {
+		// Handle context package name aliases.
+		path := imp.Path.Value
+		match := false
+		for _, pkg := range contextPackages {
+			// Add quotation marks to the package path.
+			if path == fmt.Sprintf(`"%s"`, pkg) {
+				match = true
+			}
+		}
+		if !match {
+			continue
+		}
+		pkgName := imp.Name.String()
+		if imp.Name == nil {
+			pkgName = "context"
+		}
+
+		f.walk(func(node ast.Node) bool {
+			var funcType *ast.FuncType
+			if fd, ok := node.(*ast.FuncDecl); ok {
+				funcType = fd.Type
+			} else if fl, ok := node.(*ast.FuncLit); ok {
+				funcType = fl.Type
+			} else {
+				return true
+			}
+
+			// Find context.Context arguments.
+			var names []string
+			for _, field := range funcType.Params.List {
+				if !isPkgDot(field.Type, pkgName, "Context") {
+					continue
+				}
+				for _, name := range field.Names {
+					names = append(names, name.String())
+				}
+			}
+			if len(names) == 0 {
+				return true
+			}
+
+			// Check for context.TODO() in the function body.
+			ast.Walk(walker(func(node ast.Node) bool {
+				if ce, ok := node.(*ast.CallExpr); ok {
+					if isPkgDot(ce.Fun, pkgName, "TODO") {
+						f.errorf(ce, 0.9, category("context"), "should use one of %+v instead of %s.TODO()", names, pkgName)
+					}
+				}
+				return true
+			}), node)
+
+			return true
+		})
+	}
 }
 
 func receiverType(fn *ast.FuncDecl) string {

--- a/testdata/context.go
+++ b/testdata/context.go
@@ -1,0 +1,42 @@
+// Test occurrences of context.TODO() in a function that takes a context.Context
+// argument.
+
+// Package pkg does something.
+package pkg
+
+import (
+	"context"
+	context2 "context"
+
+	contextFoo "example.com/contextFoo"
+
+	context3 "golang.org/x/net/context"
+)
+
+func hasContext(ctx context.Context, b int, ctx2, ctx3 context.Context) context.Context {
+	return context.TODO() // MATCH /should use one of \[ctx ctx2 ctx3\] instead of context.TODO\(\)/
+}
+
+func hasContext(ctx context2.Context, b int, ctx2, ctx3 context2.Context) context2.Context {
+	return context2.TODO() // MATCH /should use one of \[ctx ctx2 ctx3\] instead of context2.TODO\(\)/
+}
+
+func hasContext3(ctx context3.Context, b int, ctx2, ctx3 context3.Context) context3.Context {
+	return context3.TODO() // MATCH /should use one of \[ctx ctx2 ctx3\] instead of context3.TODO\(\)/
+}
+
+func hasContextFoo(ctx contextFoo.Context, b int, ctx2, ctx3 contextFoo.Context) contextFoo.Context {
+	return contextFoo.TODO()
+}
+
+func hasFuncLitContext(ctx context2.Context) {
+	func() {
+		context2.TODO() // MATCH /should use one of \[ctx\] instead of context2.TODO\(\)/
+	}()
+}
+
+func hasFuncLitContextArg() {
+	func(ctx context2.Context) {
+		context2.TODO() // MATCH /should use one of \[ctx\] instead of context2.TODO\(\)/
+	}(context2.Background())
+}

--- a/testdata/context_test.go
+++ b/testdata/context_test.go
@@ -1,0 +1,22 @@
+// Test occurrences of context.TODO() in a function that takes a context.Context
+// argument.
+
+// Package pkg_test does something.
+package pkg_test
+
+import (
+	"context"
+	context2 "context"
+
+	contextFoo "example.com/contextFoo"
+
+	context3 "golang.org/x/net/context"
+)
+
+func TestBar() {
+	context.TODO()  // MATCH /should use context.Background\(\) instead of context.TODO\(\) in tests/
+	context2.TODO() // MATCH /should use context.Background\(\) instead of context2.TODO\(\) in tests/
+	context3.TODO() // MATCH /should use context.Background\(\) instead of context3.TODO\(\) in tests/
+
+	contextFoo.TODO()
+}


### PR DESCRIPTION
This adds a check for `context.TODO()` in functions that have a `context.Context` parameter and suggests using that instead.

I think that this would be a nice check to have especially now that the `context` package is going to be part of stdlib.

Relates to https://github.com/cockroachdb/cockroach/issues/1779.