### PR TITLE
Skip the "context.Context should be the first parameter of a function" error if the first parameter is *testing.T

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1446,10 +1446,11 @@ func (f *file) lintContextArgs() {
 		if !ok || len(fn.Type.Params.List) <= 1 {
 			return true
 		}
-		// A context.Context should be the first parameter of a function.
+		firstParamIsTestingT := isStarPkgDot(fn.Type.Params.List[0].Type, "testing", "T")
+		// A context.Context should be the first parameter of a function, unless the first parameter is *testing.T.
 		// Flag any that show up after the first.
 		for _, arg := range fn.Type.Params.List[1:] {
-			if isPkgDot(arg.Type, "context", "Context") {
+			if isPkgDot(arg.Type, "context", "Context") && !firstParamIsTestingT {
 				f.errorf(fn, 0.9, link("https://golang.org/pkg/context/"), category("arg-order"), "context.Context should be the first parameter of a function")
 				break // only flag one
 			}
@@ -1515,6 +1516,15 @@ func isBlank(id *ast.Ident) bool { return id != nil && id.Name == "_" }
 
 func isPkgDot(expr ast.Expr, pkg, name string) bool {
 	sel, ok := expr.(*ast.SelectorExpr)
+	return ok && isIdent(sel.X, pkg) && isIdent(sel.Sel, name)
+}
+
+func isStarPkgDot(expr ast.Expr, pkg, name string) bool {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := star.X.(*ast.SelectorExpr)
 	return ok && isIdent(sel.X, pkg) && isIdent(sel.Sel, name)
 }
 

--- a/testdata/context.go
+++ b/testdata/context.go
@@ -5,6 +5,7 @@ package foo
 
 import (
 	"context"
+	"testing"
 )
 
 // A proper context.Context location
@@ -13,6 +14,10 @@ func x(ctx context.Context) { // ok
 
 // A proper context.Context location
 func x(ctx context.Context, s string) { // ok
+}
+
+// A proper context.Context location as well
+func x(t *testing.T, ctx context.Context, s string) { // ok
 }
 
 // An invalid context.Context location


### PR DESCRIPTION
I'd like to suggest skipping the "context.Context should be the first parameter of a function" error if the first parameter is `*testing.T`.

The PR allows a code like this:

```go
package foo

import (
  "context"
  "testing"
)

func checkSomething(t *testing.T, ctx context.Context, i int) { .. }

func TestFoo(t *testing.T){
  ctx := ..
  checkSomething(t, ctx, 42)
}
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>