### PR TITLE
Ignore invalid types as keys in context.WithValue()

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1429,7 +1429,7 @@ func (f *file) checkContextKeyType(x *ast.CallExpr) {
 	}
 	key := f.pkg.typesInfo.Types[x.Args[1]]
 
-	if _, ok := key.Type.(*types.Basic); ok {
+	if ktyp, ok := key.Type.(*types.Basic); ok && ktyp.Kind() != types.Invalid {
 		f.errorf(x, 1.0, category("context"), fmt.Sprintf("should not use basic type %s as key in context.WithValue", key.Type))
 	}
 }

--- a/testdata/contextkeytypes.go
+++ b/testdata/contextkeytypes.go
@@ -34,4 +34,5 @@ func contextKeyTypeTests() {
 	context.WithValue(c, complex128(1i), "bar") // MATCH /should not use basic type complex128 as key in context.WithValue/
 	context.WithValue(c, ctxKey{}, "bar")       // ok
 	context.WithValue(c, &ctxKey{}, "bar")      // ok
+	context.WithValue(c, invalid{}, "bar")      // ok
 }


### PR DESCRIPTION
There appears to be an edge case where, if the type checker wasn't able to determine the type, it's invalid, but invalid types are basic types.

For example, if the type is defined in a different file than what golint is checking.

The existing behaviour may be correct, and I don't mind if this is closed as won't-fix, but this does help reduce false positives when the type couldn't be determined.

References #245 

cc @mdlayher 