### PR TITLE
Support multiple packages and directories as golint targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Golint requires Go 1.6 or later.
 
 ## Usage
 
-Invoke `golint` with one or more filenames, a directory, or a package named
+Invoke `golint` with one or more filenames, directories, or packages named
 by its import path. Golint uses the same
 [import path syntax](https://golang.org/cmd/go/#hdr-Import_path_syntax) as
 the `go` command and therefore

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -28,9 +28,9 @@ var (
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 	fmt.Fprintf(os.Stderr, "\tgolint [flags] # runs on package in current directory\n")
-	fmt.Fprintf(os.Stderr, "\tgolint [flags] packages\n")
-	fmt.Fprintf(os.Stderr, "\tgolint [flags] directory...\n")
-	fmt.Fprintf(os.Stderr, "\tgolint [flags] files... # must be a single package\n")
+	fmt.Fprintf(os.Stderr, "\tgolint [flags] [packages]\n")
+	fmt.Fprintf(os.Stderr, "\tgolint [flags] [directories] # where a '/...' suffix includes all sub-directories\n")
+	fmt.Fprintf(os.Stderr, "\tgolint [flags] [files] # must be a single package\n")
 	fmt.Fprintf(os.Stderr, "Flags:\n")
 	flag.PrintDefaults()
 }

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -49,7 +49,7 @@ func main() {
 		var dirsRun, filesRun, pkgRun bool
 		args := make([]string, 0, flag.NArg())
 		for _, arg := range flag.Args() {
-			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-4]) {
+			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
 				dirsRun = true
 				for _, dirname := range allPackagesInFS(arg) {
 					args = append(args, dirname)


### PR DESCRIPTION
Fix #270

See #270 for rationale.

It addes support of multiple direcotries as target as well along with multiple packages, because it becomes simpler and it t also fixed https://github.com/golang/lint/issues/254