### PR TITLE
Configure build.Default to lint all files regardless of build tags

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -35,6 +35,10 @@ func usage() {
 	flag.PrintDefaults()
 }
 
+func init() {
+	build.Default.UseAllFiles = true
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()


### PR DESCRIPTION
This ensures files for other archs are linted.