### PR TITLE
Update travis for go1.8 + tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: go
 go:
-  - 1.6
   - 1.7
+  - 1.8
+  - tip
 
 install:
   - go get -t -v ./...
 
 script:
   - go test -v ./...
+
+matrix:
+  allow_failures:
+  - go: tip


### PR DESCRIPTION
Update golint testing to use go1.8 and to test against tip (but permit failures)