### PR TITLE
Update .travis.yml for latest conventions, use fast_finish, test with -race.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: go
 go:
   - 1.7.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: go
 go:
-  - 1.7
-  - 1.8
-  - tip
+  - 1.7.x
+  - 1.8.x
+  - master
 
 install:
   - go get -t -v ./...
 
 script:
-  - go test -v ./...
+  - go test -v -race ./...
 
 matrix:
   allow_failures:
-  - go: tip
+    - go: master
+  fast_finish: true


### PR DESCRIPTION
Please consider these changes to `.travis.yml` that follow #277:

- Update to use latest conventions as documented at https://docs.travis-ci.com/user/languages/go#Specifying-a-Go-version-to-use. Specifically, use `master` instead of `tip` to refer to latest (unreleased) version of Go.

- Use `.x` to target latest patch releases of each point release of Go.

- Use `fast_finish` to speed up build reporting with no semantic change. It's documented at https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/.

- Use race detector when running tests. It should be a good idea to do this.

- Do not require `sudo` access, since it's not required. This allows Travis to use [container-based infrastructure](https://docs.travis-ci.com/user/migrating-from-legacy/).

I'm happy to receive feedback on the changes and discuss them. I wanted to contribute these improvements because this is a visible project, and I want its `.travis.yml` file to serve a better role model for people learning how they can structure their `.travis.yml` file for their Go repositories.