### PR TITLE
Add check for MixedCaps in package name

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -527,7 +527,10 @@ func (f *file) lintExported() {
 	})
 }
 
-var allCapsRE = regexp.MustCompile(`^[A-Z0-9_]+$`)
+var (
+	allCapsRE = regexp.MustCompile(`^[A-Z0-9_]+$`)
+	anyCapsRE = regexp.MustCompile(`[A-Z]`)
+)
 
 // knownNameExceptions is a set of names that are known to be exempt from naming checks.
 // This is usually because they are constrained by having to match names in the
@@ -543,6 +546,9 @@ func (f *file) lintNames() {
 	// Package names need slightly different handling than other names.
 	if strings.Contains(f.f.Name.Name, "_") && !strings.HasSuffix(f.f.Name.Name, "_test") {
 		f.errorf(f.f, 1, link("http://golang.org/doc/effective_go.html#package-names"), category("naming"), "don't use an underscore in package name")
+	}
+	if anyCapsRE.MatchString(f.f.Name.Name) {
+		f.errorf(f.f, 1, link("http://golang.org/doc/effective_go.html#package-names"), category("mixed-caps"), "don't use MixedCaps in package name; %s should be %s", f.f.Name.Name, strings.ToLower(f.f.Name.Name))
 	}
 
 	check := func(id *ast.Ident, thing string) {

--- a/testdata/pkg-caps.go
+++ b/testdata/pkg-caps.go
@@ -1,0 +1,4 @@
+// MixedCaps package name
+
+// Package PkgName ...
+package PkgName // MATCH /don't use MixedCaps in package name/


### PR DESCRIPTION
Lint already checks for underscores in package names, but did not yet
check for lower case names. The section on Package names in the
Effective Go document states that "By convention, packages packages are
given lower case, single-word names; there should be no need for
underscores or mixedCaps."