### PR TITLE
Prevent panic in case there are no files to check.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -279,6 +279,9 @@ func (p *pkg) typeCheck() error {
 		anyFile = f
 		astFiles = append(astFiles, f.f)
 	}
+	if anyFile == nil {
+		return nil
+	}
 	pkg, err := config.Check(anyFile.f.Name.Name, p.fset, astFiles, info)
 	// Remember the typechecking info, even if config.Check failed,
 	// since we will get partial information.

--- a/lint.go
+++ b/lint.go
@@ -82,9 +82,6 @@ func (l *Linter) Lint(filename string, src []byte) ([]Problem, error) {
 // LintFiles lints a set of files of a single package.
 // The argument is a map of filename to source.
 func (l *Linter) LintFiles(files map[string][]byte) ([]Problem, error) {
-	if len(files) == 0 {
-		return nil, nil
-	}
 	pkg := &pkg{
 		fset:  token.NewFileSet(),
 		files: make(map[string]*file),
@@ -110,6 +107,9 @@ func (l *Linter) LintFiles(files map[string][]byte) ([]Problem, error) {
 			src:      src,
 			filename: filename,
 		}
+	}
+	if len(pkg.files) == 0 {
+		return nil, nil
 	}
 	return pkg.lint(), nil
 }
@@ -278,9 +278,6 @@ func (p *pkg) typeCheck() error {
 	for _, f := range p.files {
 		anyFile = f
 		astFiles = append(astFiles, f.f)
-	}
-	if anyFile == nil {
-		return nil
 	}
 	pkg, err := config.Check(anyFile.f.Name.Name, p.fset, astFiles, info)
 	// Remember the typechecking info, even if config.Check failed,


### PR DESCRIPTION
As with issue #239 auto-generated files are skipped now. In case some packages consist of auto-generated files only, golint panics on nil pointer dereference. This PR fixes this issue.