### PR TITLE
golint: add flag to ignore vendor dirs

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -22,6 +22,7 @@ import (
 var (
 	minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
 	setExitStatus = flag.Bool("set_exit_status", false, "set exit status to 1 if any issues are found")
+	checkVendor = flag.Bool("vendor", false, "include packages in vendor dirs when expanding ...")
 	suggestions   int
 )
 
@@ -51,6 +52,9 @@ func main() {
 			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
 				dirsRun = 1
 				for _, dirname := range allPackagesInFS(arg) {
+					if !*checkVendor && strings.Contains("/" + dirname, "/vendor/") {
+						continue
+					}
 					args = append(args, dirname)
 				}
 			} else if isDir(arg) {


### PR DESCRIPTION
A typical usage for a project is: golint ./...
Scanning all vendored packages creates noise,
takes time and is usually not useful.

Add -vendor flag that controls inclusion of vendor
dirs during ... expansion.

Note: this changes default behavior as the default
value for the flag is false. This is debatable.
The rationale for false is:
 - go tool at tip ignores vendor during fmt and test
 - people generally don't want to change vendored
   packages, especially for style