### PR TITLE
Improve receiver name underscore message.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1237,7 +1237,7 @@ func (f *file) lintReceiverNames() {
 		name := names[0].Name
 		const ref = styleGuideBase + "#receiver-names"
 		if name == "_" {
-			f.errorf(n, 1, link(ref), category("naming"), `receiver name should not be an underscore`)
+			f.errorf(n, 1, link(ref), category("naming"), `receiver name should not be an underscore, omit the name if it is unused`)
 			return true
 		}
 		if name == "this" || name == "self" {


### PR DESCRIPTION
Remind users that they can omit a receiver name entirely instead of
using an underscore for an unused receiver argument.
Fixes #310.