### PR TITLE
Adding checkstyle-xml output format

### DIFF
--- a/golint/checkstyle.go
+++ b/golint/checkstyle.go
@@ -1,0 +1,77 @@
+package main
+
+import "encoding/xml"
+
+// DefaultCheckStyleVersion defines the default "version" attribute on "<checkstyle>" lememnt
+var DefaultCheckStyleVersion = "1.0.0"
+
+// CheckStyle represents a <checkstle> xml element.
+type CheckStyle struct {
+	XMLName xml.Name          `xml:"checkstyle"`
+	Version string            `xml:"version,attr"`
+	File    []*CheckStyleFile `xml:"file"`
+}
+
+// AddFile adds a CheckStyleFile with the given filename.
+func (cs *CheckStyle) AddFile(csf *CheckStyleFile) {
+	cs.File = append(cs.File, csf)
+}
+
+// GetFile gets a CheckStyleFile with the given filename.
+func (cs *CheckStyle) GetFile(filename string) (csf *CheckStyleFile, ok bool) {
+	for _, file := range cs.File {
+		if file.Name == filename {
+			csf = file
+			ok = true
+			return
+		}
+	}
+	return
+}
+
+// EnsureFile ensures that a CheckStyleFile with the given name exists
+// Returns either an exiting CheckStyleFile (if a file with that name exists)
+// or a new CheckStyleFile (if a file with that name does not exists)
+func (cs *CheckStyle) EnsureFile(filename string) (csf *CheckStyleFile) {
+	csf, ok := cs.GetFile(filename)
+	if !ok {
+		csf = NewCheckStyleFile(filename)
+		cs.AddFile(csf)
+	}
+	return csf
+}
+
+// NewCheckStyle returns a new CheckStyle
+func NewCheckStyle() CheckStyle {
+	return CheckStyle{Version: DefaultCheckStyleVersion, File: []*CheckStyleFile{}}
+}
+
+// CheckStyleFile represents a <file> xml element.
+type CheckStyleFile struct {
+	XMLName xml.Name           `xml:"file"`
+	Name    string             `xml:"name,attr"`
+	Error   []*CheckStyleError `xml:"error"`
+}
+
+// AddError adds a CheckStyleError to the file.
+func (csf *CheckStyleFile) AddError(cse *CheckStyleError) {
+	csf.Error = append(csf.Error, cse)
+}
+
+// NewCheckStyleFile creates a new CheckStyleFile.
+func NewCheckStyleFile(filename string) *CheckStyleFile {
+	return &CheckStyleFile{Name: filename, Error: []*CheckStyleError{}}
+}
+
+// CheckStyleError represents a <error> xml element
+type CheckStyleError struct {
+	XMLName xml.Name `xml:"error"`
+	Line    int      `xml:"line,attr"`
+	Message string   `xml:"message,attr"`
+	Source  string   `xml:"source,attr"`
+}
+
+// NewCheckStyleError creates a new CheckStyleError
+func NewCheckStyleError(line int, message string, source string) *CheckStyleError {
+	return &CheckStyleError{Line: line, Message: message, Source: source}
+}

--- a/golint/checkstyle_test.go
+++ b/golint/checkstyle_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/xml"
+	"reflect"
+	"testing"
+)
+
+func TestCheckStyle(t *testing.T) {
+	xmlString := `<?xml version="1.0" encoding="UTF-8"?>
+	<checkstyle version="1.0.0">
+			<file name="/path/to/code/myfile.go">
+					<error line="2"  message="msg1" source="Ruleset.RuleName"/>
+					<error line="20"  message="msg2" source="Generic.Constant"/>
+					<error line="47"  message="msg3" source="ScopeIndent"/>
+					<error line="47" message="msg4" source="Format.MultipleAlignment"/>
+					<error line="51" message="msg5" source="Comment.FunctionComment"/>
+			</file>
+	</checkstyle>`
+
+	checkStyleElement := CheckStyle{}
+	err := xml.Unmarshal([]byte(xmlString), &checkStyleElement)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// <checkstyle>
+	if checkStyleElement.Version != "1.0.0" {
+		t.Error("Bad checkstyle version")
+	}
+	if len(checkStyleElement.File) != 1 {
+		t.Error("Wrong number of child <file> elements")
+	}
+
+	// <file>
+	fileElement := checkStyleElement.File[0]
+	if fileElement.Name != "/path/to/code/myfile.go" {
+		t.Error("Bad file name")
+	}
+	if len(fileElement.Error) != 5 {
+		t.Error("Wrong number of child <error> elements")
+	}
+
+	// <error>
+	errorElement := fileElement.Error[0]
+	if errorElement.Line != 2 {
+		t.Error("Bad line number")
+	}
+	if errorElement.Message != "msg1" {
+		t.Error("Bad error message")
+	}
+	if errorElement.Source != "Ruleset.RuleName" {
+		t.Error("Bad error source")
+	}
+
+	// Test round trip
+	roundtripXML, err := xml.Marshal(checkStyleElement)
+	if err != nil {
+		t.Error(err)
+	}
+	roundtrip := CheckStyle{}
+	err = xml.Unmarshal(roundtripXML, &roundtrip)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(roundtrip, checkStyleElement) {
+		t.Error("Round Trip failed")
+	}
+
+}


### PR DESCRIPTION
Checkstyle is an XML output format for source-code checkers. This will provides interoperability with both IDEs and editors that expect code suggestions in checkstyle format, as well as online checkers such as scrutinizer-ci. 

An example of this patch in action:
```bash
> golint -output_format=checkstyle-xml
<checkstyle version="1.0.0"><file name="checkstyle.go"><error line="20" message="comment on exported method CheckStyle.GetFile should be of the form &#34;GetFile ...&#34;" source="comments"></error></file></checkstyle>
```