### PR TITLE
Ignore `/vendor/` by default when linting

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -22,6 +22,7 @@ import (
 var (
 	minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
 	setExitStatus = flag.Bool("set_exit_status", false, "set exit status to 1 if any issues are found")
+	checkVendor = flag.Bool("vendor", false, "include packages in vendor dirs when expanding ...")
 	suggestions   int
 )
 
@@ -51,6 +52,9 @@ func main() {
 			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
 				dirsRun = 1
 				for _, dirname := range allPackagesInFS(arg) {
+					if !*checkVendor && strings.Contains("/" + dirname, "/vendor/") {
+						continue
+					}
 					args = append(args, dirname)
 				}
 			} else if isDir(arg) {

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -22,7 +22,6 @@ import (
 var (
 	minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
 	setExitStatus = flag.Bool("set_exit_status", false, "set exit status to 1 if any issues are found")
-	checkVendor   = flag.Bool("vendor", false, "include packages in vendor dirs when expanding ...")
 	suggestions   int
 )
 
@@ -52,7 +51,7 @@ func main() {
 			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
 				dirsRun = 1
 				for _, dirname := range allPackagesInFS(arg) {
-					if !*checkVendor && strings.Contains("/" + dirname, "/vendor/") {
+					if strings.Contains("/"+dirname, "/vendor/") {
 						continue
 					}
 					args = append(args, dirname)

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -47,11 +47,12 @@ func main() {
 		// checks are run. It is no valid to mix target types.
 		var dirsRun, filesRun, pkgsRun int
 		var args []string
-		for _, arg := range flag.Args() {
-			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
+		for _, arg := range flag.Args()  {
+			basePath := arg[:len(arg)-len("/...")]
+			if strings.HasSuffix(arg, "/...") && isDir(basePath) {
 				dirsRun = 1
 				for _, dirname := range allPackagesInFS(arg) {
-					if strings.Contains("/"+dirname, "/vendor/") {
+					if strings.Contains(dirname[len(basePath):], "/vendor/") {
 						continue
 					}
 					args = append(args, dirname)

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -22,7 +22,7 @@ import (
 var (
 	minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
 	setExitStatus = flag.Bool("set_exit_status", false, "set exit status to 1 if any issues are found")
-	checkVendor = flag.Bool("vendor", false, "include packages in vendor dirs when expanding ...")
+	checkVendor   = flag.Bool("vendor", false, "include packages in vendor dirs when expanding ...")
 	suggestions   int
 )
 

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -47,12 +47,11 @@ func main() {
 		// checks are run. It is no valid to mix target types.
 		var dirsRun, filesRun, pkgsRun int
 		var args []string
-		for _, arg := range flag.Args()  {
-			basePath := arg[:len(arg)-len("/...")]
-			if strings.HasSuffix(arg, "/...") && isDir(basePath) {
+		for _, arg := range flag.Args() {
+			if trimmedArg := strings.TrimSuffix(arg, "/..."); trimmedArg != arg && isDir(trimmedArg) {
 				dirsRun = 1
 				for _, dirname := range allPackagesInFS(arg) {
-					if strings.Contains(dirname[len(basePath):], "/vendor/") {
+					if strings.Contains(dirname[len(trimmedArg):], "/vendor/") {
 						continue
 					}
 					args = append(args, dirname)


### PR DESCRIPTION
I'd like to continue from #303. All credits go to @dvyukov's work.

This PR will ignore `/vendor/` by default when linting. But `golint ./vendor/...` will still lint that `vendor` directory normally.

This'll fix #320 and fix #151.