### PR TITLE
Detecting the use of "..." as documentation.

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -425,6 +425,11 @@ func (f *file) lintPackageComment() {
 	// Only non-main packages need to keep to this form.
 	if !f.pkg.main && !strings.HasPrefix(s, prefix) {
 		f.errorf(f.f.Doc, 1, link(ref), category("comments"), `package comment should be of the form "%s..."`, prefix)
+		return
+	}
+
+	if !f.pkg.main && strings.HasPrefix(s, prefix+"...") {
+		f.errorf(f.f.Doc, 1, link(ref), category("comments"), "package comment should be a complete sentence")
 	}
 }
 
@@ -804,6 +809,10 @@ func (f *file) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 	if !strings.HasPrefix(s, t.Name.Name+" ") {
 		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported type %v should be of the form "%v ..." (with optional leading article)`, t.Name, t.Name)
 	}
+
+	if strings.HasPrefix(s, t.Name.Name+" ...") {
+		f.errorf(doc, 1, link(docCommentsLink), category("comments"), "comment on exported type %v should be a complete sentence", t.Name)
+	}
 }
 
 var commonMethods = map[string]bool{
@@ -851,6 +860,12 @@ func (f *file) lintFuncDoc(fn *ast.FuncDecl) {
 	prefix := fn.Name.Name + " "
 	if !strings.HasPrefix(s, prefix) {
 		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "%s..."`, kind, name, prefix)
+		return
+	}
+
+	prefix = prefix + "..."
+	if strings.HasPrefix(s, prefix) {
+		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comments"), "comment on exported %s %s should be a complete sentence", kind, name)
 	}
 }
 
@@ -904,6 +919,12 @@ func (f *file) lintValueSpecDoc(vs *ast.ValueSpec, gd *ast.GenDecl, genDeclMissi
 	prefix := name + " "
 	if !strings.HasPrefix(doc.Text(), prefix) {
 		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "%s..."`, kind, name, prefix)
+		return
+	}
+
+	prefix = prefix + "..."
+	if strings.HasPrefix(doc.Text(), prefix) {
+		f.errorf(doc, 1, link(docCommentsLink), category("comments"), "comment on exported %s %s should be a complete sentence", kind, name)
 	}
 }
 

--- a/testdata/blank-import-lib.go
+++ b/testdata/blank-import-lib.go
@@ -1,6 +1,6 @@
 // Test that blank imports in library packages are flagged.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 // The instructions need to go before the imports below so they will not be

--- a/testdata/blank-import-lib_test.go
+++ b/testdata/blank-import-lib_test.go
@@ -1,7 +1,7 @@
 // Test that blank imports in test packages are not flagged.
 // OK
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 // These are essentially the same imports as in the "library" package, but

--- a/testdata/blank-import-main.go
+++ b/testdata/blank-import-main.go
@@ -1,7 +1,7 @@
 // Test that blank imports in package main are not flagged.
 // OK
 
-// Binary foo ...
+// Binary foo does something.
 package main
 
 import _ "fmt"

--- a/testdata/broken.go
+++ b/testdata/broken.go
@@ -2,7 +2,7 @@
 // See https://golang.org/issue/11271 for discussion.
 // OK
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 // Foo is a method with a missing receiver.

--- a/testdata/common-methods.go
+++ b/testdata/common-methods.go
@@ -1,12 +1,12 @@
 // Test that we don't nag for comments on common methods.
 // OK
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 import "net/http"
 
-// T is ...
+// T is a server of sorts.
 type T int
 
 func (T) Error() string                                    { return "" }

--- a/testdata/const-block.go
+++ b/testdata/const-block.go
@@ -1,6 +1,6 @@
 // Test for docs in const blocks
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 const (

--- a/testdata/context.go
+++ b/testdata/context.go
@@ -1,6 +1,6 @@
 // Test that context.Context is the first arg to a function.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import (

--- a/testdata/else-multi.go
+++ b/testdata/else-multi.go
@@ -1,7 +1,7 @@
 // Test of return+else warning; should not trigger on multi-branch if/else.
 // OK
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 import "log"

--- a/testdata/else.go
+++ b/testdata/else.go
@@ -1,6 +1,6 @@
 // Test of return+else warning.
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 import "log"

--- a/testdata/error-return.go
+++ b/testdata/error-return.go
@@ -1,6 +1,6 @@
 // Test for returning errors.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 // Returns nothing

--- a/testdata/errorf.go
+++ b/testdata/errorf.go
@@ -1,6 +1,6 @@
 // Test for not using fmt.Errorf or testing.Errorf.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import (

--- a/testdata/errors.go
+++ b/testdata/errors.go
@@ -1,6 +1,6 @@
 // Test for naming errors.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import (
@@ -10,12 +10,12 @@ import (
 
 var unexp = errors.New("some unexported error") // MATCH /error var.*unexp.*errFoo/
 
-// Exp ...
+// Exp is returned when some error happens.
 var Exp = errors.New("some exported error") // MATCH /error var.*Exp.*ErrFoo/
 
 var (
 	e1 = fmt.Errorf("blah %d", 4) // MATCH /error var.*e1.*errFoo/
-	// E2 ...
+	// E2 is returned when that other error happens.
 	E2 = fmt.Errorf("blah %d", 5) // MATCH /error var.*E2.*ErrFoo/
 )
 

--- a/testdata/iferr.go
+++ b/testdata/iferr.go
@@ -1,6 +1,6 @@
 // Test of redundant if err != nil
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 func f() error {

--- a/testdata/import-dot.go
+++ b/testdata/import-dot.go
@@ -1,6 +1,6 @@
 // Test that dot imports are flagged.
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 import . "fmt" // MATCH /dot import/

--- a/testdata/inc.go
+++ b/testdata/inc.go
@@ -1,6 +1,6 @@
 // Test for use of x++ and x--.
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
 func addOne(x int) int {

--- a/testdata/names.go
+++ b/testdata/names.go
@@ -1,6 +1,6 @@
 // Test for name linting.
 
-// Package pkg_with_underscores ...
+// Package pkg_with_underscores does something.
 package pkg_with_underscores // MATCH /underscore.*package name/
 
 import (

--- a/testdata/pkg-doc6.go
+++ b/testdata/pkg-doc6.go
@@ -1,0 +1,6 @@
+// Test of detached package comment.
+
+// Package foo ...
+package foo
+
+// MATCH:3 /package comment should be a complete sentence/

--- a/testdata/range.go
+++ b/testdata/range.go
@@ -1,6 +1,6 @@
 // Test for range construction.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 func f() {

--- a/testdata/receiver-names.go
+++ b/testdata/receiver-names.go
@@ -1,6 +1,6 @@
 // Test for bad receiver names.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 type foo struct{}

--- a/testdata/sort.go
+++ b/testdata/sort.go
@@ -1,16 +1,16 @@
 // Test that we don't ask for comments on sort.Interface methods.
 
-// Package pkg ...
+// Package pkg does something.
 package pkg
 
-// T is ...
+// T is an awesome slice.
 type T []int
 
 // Len by itself should get documented.
 
 func (t T) Len() int { return len(t) } // MATCH /exported method T\.Len.*should.*comment/
 
-// U is ...
+// U is an even better slice than T.
 type U []int
 
 func (u U) Len() int           { return len(u) }

--- a/testdata/stutter.go
+++ b/testdata/stutter.go
@@ -1,6 +1,6 @@
 // Test of stuttery names.
 
-// Package donut ...
+// Package donut does something.
 package donut
 
 // DonutMaker makes donuts.

--- a/testdata/time.go
+++ b/testdata/time.go
@@ -1,6 +1,6 @@
 // Test of time suffixes.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import (

--- a/testdata/unexp-return.go
+++ b/testdata/unexp-return.go
@@ -1,6 +1,6 @@
 // Test for unexported return types.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import ()

--- a/testdata/var-decl.go
+++ b/testdata/var-decl.go
@@ -1,6 +1,6 @@
 // Test for redundant type declaration.
 
-// Package foo ...
+// Package foo does something.
 package foo
 
 import (


### PR DESCRIPTION
An ellipses is often used to circumvent the comment checks of this tool. Given that both Effective-Go and the CodeReviewComments wiki both state that comments should use complete sentences, it seems like this should be something that this should check for.