### PR TITLE
Allow for custom build tags when linting a package or directory

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -22,6 +22,7 @@ import (
 var (
 	minConfidence = flag.Float64("min_confidence", 0.8, "minimum confidence of a problem to print it")
 	setExitStatus = flag.Bool("set_exit_status", false, "set exit status to 1 if any issues are found")
+	buildTags     = flag.String("tags", "", "space-separated list of additional build tags to use")
 	suggestions   int
 )
 
@@ -124,13 +125,24 @@ func lintFiles(filenames ...string) {
 	}
 }
 
+func getBuildCtx() *build.Context {
+	ctx := build.Default
+
+	if *buildTags != "" {
+		tags := strings.Split(*buildTags, " ")
+		ctx.BuildTags = append(ctx.BuildTags, tags...)
+	}
+
+	return &ctx
+}
+
 func lintDir(dirname string) {
-	pkg, err := build.ImportDir(dirname, 0)
+	pkg, err := getBuildCtx().ImportDir(dirname, 0)
 	lintImportedPackage(pkg, err)
 }
 
 func lintPackage(pkgname string) {
-	pkg, err := build.Import(pkgname, ".", 0)
+	pkg, err := getBuildCtx().Import(pkgname, ".", 0)
 	lintImportedPackage(pkg, err)
 }
 


### PR DESCRIPTION
Allow build tags to be specified when linting a package or directory, and use the specified build tags when generating the list of files to lint.

Note that there are two similar pre-existing PRs, with slight differences:
* #276 lints all files regardless of tags. Allowing tags to be specified gives the user more control over what gets linted, but in practice linting everything may be a more desirable behavior.
* #153 also allows tags to be specified, but passes those tags through the entire lint mechanism. Using tags only to generate a list of files to lint is a much simpler change and, I believe, has the same desired effect.