### PR TITLE
Specify exact license in header of Emacs lisp library

### DIFF
--- a/misc/emacs/golint.el
+++ b/misc/emacs/golint.el
@@ -1,9 +1,8 @@
 ;;; golint.el --- lint for the Go source code
 
 ;; Copyright 2013 The Go Authors. All rights reserved.
-;; Use of this source code is governed by a BSD-style
-;; license that can be found in the LICENSE file.
 
+;; License: BSD-3-clause
 ;; URL: https://github.com/golang/lint
 
 ;;; Commentary:

--- a/misc/emacs/golint.el
+++ b/misc/emacs/golint.el
@@ -16,15 +16,16 @@
 ;; Usage:
 ;;   C-x `
 ;;     Jump directly to the line in your code which caused the first message.
-;; 
+;;
 ;;   For more usage, see Compilation-Mode:
 ;;     http://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation-Mode.html
 
 ;;; Code:
+
 (require 'compile)
 
-(defun go-lint-buffer-name (mode) 
- "*Golint*") 
+(defun go-lint-buffer-name (mode)
+  "*Golint*")
 
 (defun golint-process-setup ()
   "Setup compilation variables and buffer for `golint'."
@@ -35,8 +36,7 @@
   (set (make-local-variable 'compilation-scroll-output) nil)
   (set (make-local-variable 'compilation-disable-input) t)
   (set (make-local-variable 'compilation-process-setup-function)
-       'golint-process-setup)
-)
+       'golint-process-setup))
 
 ;;;###autoload
 (defun golint ()

--- a/misc/emacs/golint.el
+++ b/misc/emacs/golint.el
@@ -40,7 +40,9 @@
 
 ;;;###autoload
 (defun golint ()
-  "Run golint on the current file and populate the fix list. Pressing C-x ` will jump directly to the line in your code which caused the first message."
+  "Run golint on the current file and populate the fix list.
+Pressing \"C-x `\" jumps directly to the line in your code which
+caused the first message."
   (interactive)
   (compilation-start
    (mapconcat #'shell-quote-argument


### PR DESCRIPTION
Emacs packages are often distributed by themselves (e.g. on Melpa
and the Emacsmirror) even when they are developed in a repository
that other files beside the Elisp libraries.  In such cases it
should still be possible to tell what the license is, so replace
"BSD-style license" with "BSD-3-clause" and use the standard
"License" header keyword to do so.

While at it, I removed whitespace errors and improved a doc-string.
