### PR TITLE
lint: fix if/else if/else if/else return handling

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1039,11 +1039,11 @@ func (f *file) lintElses() {
 		if !ok || ifStmt.Else == nil {
 			return true
 		}
-		if ignore[ifStmt] {
-			return true
-		}
 		if elseif, ok := ifStmt.Else.(*ast.IfStmt); ok {
 			ignore[elseif] = true
+			return true
+		}
+		if ignore[ifStmt] {
 			return true
 		}
 		if _, ok := ifStmt.Else.(*ast.BlockStmt); !ok {

--- a/testdata/else-multi.go
+++ b/testdata/else-multi.go
@@ -16,3 +16,19 @@ func f(x int) bool {
 	}
 	return false
 }
+
+func issue354(x int) bool {
+	switch g {
+	case 0:
+		if x == 0 {
+			log.Print("x is zero")
+		} else if x > 0 {
+			log.Print("greater than 0")
+		} else if x < 0 {
+			return true
+		} else {
+			log.Printf("non-positive x: %d", x)
+		}
+	}
+	return false
+}


### PR DESCRIPTION
If you have multiple "else if" statements and the last one has
a return, golint will incorrectly warn that the last else can be
dedented, even if the if/first else if blocks don't.

From the issue report: "the problem is that the ignore flag is not
getting propagated to all the else's in a chain because of the early
return." Flipping the order fixes the problem.

Fixes golang/lint#354. Patch was suggested by Ramesh Vyaghrapuri, who
also identified the problem.