### PR TITLE
lint: avoid false positives with custom errors-package

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/ast/astutil"
-
 	"golang.org/x/tools/go/gcexportdata"
 )
 
@@ -1693,7 +1692,7 @@ func (f *file) srcLineWithMatch(node ast.Node, pattern string) (m []string) {
 	return rx.FindStringSubmatch(line)
 }
 
-// imports returns true if the current file imports the specified package path
+// imports returns true if the current file imports the specified package path.
 func (f *file) imports(importPath string) bool {
 	all := astutil.Imports(f.fset, f.f)
 	for _, p := range all {

--- a/lint.go
+++ b/lint.go
@@ -23,6 +23,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/tools/go/ast/astutil"
+
 	"golang.org/x/tools/go/gcexportdata"
 )
 
@@ -1115,6 +1117,9 @@ func (f *file) lintErrorf() {
 		if !isErrorsNew && !isTestingError {
 			return true
 		}
+		if !f.imports("errors") {
+			return true
+		}
 		arg := ce.Args[0]
 		ce, ok = arg.(*ast.CallExpr)
 		if !ok || !isPkgDot(ce.Fun, "fmt", "Sprintf") {
@@ -1686,6 +1691,21 @@ func (f *file) srcLineWithMatch(node ast.Node, pattern string) (m []string) {
 	line = strings.TrimSuffix(line, "\n")
 	rx := regexp.MustCompile(pattern)
 	return rx.FindStringSubmatch(line)
+}
+
+// imports returns true if the current file imports the specified package path
+func (f *file) imports(importPath string) bool {
+	all := astutil.Imports(f.fset, f.f)
+	for _, p := range all {
+		for _, i := range p {
+			uq, err := strconv.Unquote(i.Path.Value)
+			if err == nil && importPath == uq {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // srcLine returns the complete line at p, including the terminating newline.

--- a/lint.go
+++ b/lint.go
@@ -1703,7 +1703,6 @@ func (f *file) imports(importPath string) bool {
 			}
 		}
 	}
-
 	return false
 }
 

--- a/testdata/errorf-custom.go
+++ b/testdata/errorf-custom.go
@@ -1,0 +1,25 @@
+// Test for allowed errors.New(fmt.Sprintf()) when a custom errors package is imported.
+
+// Package foo ...
+package foo
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func f(x int) error {
+	if x > 10 {
+		return errors.New(fmt.Sprintf("something %d", x)) // OK
+	}
+	if x > 5 {
+		return errors.New(g("blah")) // OK
+	}
+	if x > 4 {
+		return errors.New("something else") // OK
+	}
+	return nil
+}
+
+func g(s string) string { return "prefix: " + s }


### PR DESCRIPTION
When using `errors.New(fmt.Sprintf(...))`, 
lint will alert that you should use `fmt.Errorf(...)`. 

Before this patch, this alert was also displayed 
when using a custom errors-package. 
There are valid use cases to use `errors.New(fmt.Sprintf(...))`
in a custom errors-package context.

This patch avoids the "false positive" alert
when a custom errors-package is imported in the current file. 

Fixes golang/lint#350