### PR TITLE
Test for using errors.New with a capitalized string

### DIFF
--- a/testdata/errors.go
+++ b/testdata/errors.go
@@ -33,5 +33,6 @@ func g(x int) error {
 	err = fmt.Errorf("newlines are fun\n")        // MATCH /error strings.*end with punctuation/
 	err = fmt.Errorf("Newlines are really fun\n") // MATCH /error strings.+not be capitalized/
 	err = errors.New(`too much stuff.`)           // MATCH /error strings.*end with punctuation/
+	err = errors.New("This %d is too low", x)     // MATCH /error strings.*be capitalized/
 	return err
 }


### PR DESCRIPTION
Add a test for the "error strings should not be capitalized" warning when using `errors.New`.

To be honest, I don't know if this will pass or not; I assume it will, and Travis will confirm 😄 