### PR TITLE
Exported name should have a valid end of comment.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,6 @@ If you still have problems, consider searching for existing issues before filing
 ## Before sending a pull request:
 
 Have you understood the purpose of golint? Make sure to carefully read `README`.
+
+### Run golint tests. Note that golint will report warnings on test files.
+go test -v -race ./...

--- a/testdata/4.go
+++ b/testdata/4.go
@@ -13,12 +13,27 @@ func (T) F() {} // MATCH /exported method T\.F.*should.*comment.*or.*unexport/
 // MATCH /comment.*exported type U.*should.*form.*"U ..."/
 type U string
 
+// EasyJSON struct is used for json Marshal/Unmarshal.
+//easyjson:json
+type EasyJSON struct {
+	U
+}
+
 // this is a neat function.
 // MATCH /comment.*exported method U\.G.*should.*form.*"G ..."/
 func (U) G() {}
 
+// G is a neat function. The comment ends in a period.
+func (U) G() {}
+
+// G is a neat function. The comment ends in a question mark?
+func (U) G() {}
+
 // A V is a string.
 type V string
+
+// VVar is a string.
+var VVar V
 
 // V.H has a pointer receiver
 

--- a/testdata/errorf.go
+++ b/testdata/errorf.go
@@ -22,7 +22,7 @@ func f(x int) error {
 	return nil
 }
 
-// TestF is a dummy test
+// TestF is a dummy test.
 func TestF(t *testing.T) error {
 	x := 1
 	if x > 10 {


### PR DESCRIPTION
This is a well known rule https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences.
It mentiones "period at the end" but in fact there are other symbols
that can be considered as valid:

const symbolsCanEndASentence = ".?!;\"'`\\/|)}]>/#$"

Do the check only for Exported in GO and skip exported to C.

Tests Passed.

Fix #374
Issue #374