### PR TITLE
lint: analyze missing package comment globally

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -75,7 +75,7 @@ func main() {
 				lintDir(dir)
 			}
 		case filesRun == 1:
-			lintFiles(args...)
+			lintFiles("", args...)
 		case pkgsRun == 1:
 			for _, pkg := range importPaths(args) {
 				lintPackage(pkg)
@@ -99,7 +99,7 @@ func exists(filename string) bool {
 	return err == nil
 }
 
-func lintFiles(filenames ...string) {
+func lintFiles(dir string, filenames ...string) {
 	files := make(map[string][]byte)
 	for _, filename := range filenames {
 		src, err := ioutil.ReadFile(filename)
@@ -111,7 +111,7 @@ func lintFiles(filenames ...string) {
 	}
 
 	l := new(lint.Linter)
-	ps, err := l.LintFiles(files)
+	ps, err := l.LintFiles(dir, files)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return
@@ -155,5 +155,5 @@ func lintImportedPackage(pkg *build.Package, err error) {
 	}
 	// TODO(dsymonds): Do foo_test too (pkg.XTestGoFiles)
 
-	lintFiles(files...)
+	lintFiles(pkg.Dir, files...)
 }

--- a/lint.go
+++ b/lint.go
@@ -76,13 +76,14 @@ func (p byPosition) Less(i, j int) bool {
 
 // Lint lints src.
 func (l *Linter) Lint(filename string, src []byte) ([]Problem, error) {
-	return l.LintFiles(map[string][]byte{filename: src})
+	return l.LintFiles("", map[string][]byte{filename: src})
 }
 
 // LintFiles lints a set of files of a single package.
 // The argument is a map of filename to source.
-func (l *Linter) LintFiles(files map[string][]byte) ([]Problem, error) {
+func (l *Linter) LintFiles(dir string, files map[string][]byte) ([]Problem, error) {
 	pkg := &pkg{
+		dir:   dir,
 		fset:  token.NewFileSet(),
 		files: make(map[string]*file),
 	}
@@ -134,6 +135,7 @@ func isGenerated(src []byte) bool {
 
 // pkg represents a package being linted.
 type pkg struct {
+	dir   string
 	fset  *token.FileSet
 	files map[string]*file
 
@@ -183,7 +185,7 @@ func (p *pkg) lint() []Problem {
 	}
 	if !packageCommentsOK && nonTestFiles > 0 {
 		ref := styleGuideBase + "#package-comments"
-		p.errorfAt(token.Position{Filename: "(--package--)"}, 0.8, link(ref), category("comments"),
+		p.errorfAt(token.Position{Filename: p.dir}, 0.8, link(ref), category("comments"),
 			"at least one file should have a valid package comment")
 	}
 

--- a/lint.go
+++ b/lint.go
@@ -174,16 +174,16 @@ func (p *pkg) lint() []Problem {
 	p.main = p.isMain()
 
 	packageCommentsOK := false
-	nonTestFiles := 0
+	nonTestOrMainFiles := 0
 	for _, f := range p.files {
 		if f.lintPackageComment(false) {
 			packageCommentsOK = true
 			break
-		} else if !f.isTest() {
-			nonTestFiles++
+		} else if !f.isTest() && !f.isMain() {
+			nonTestOrMainFiles++
 		}
 	}
-	if !packageCommentsOK && nonTestFiles > 0 {
+	if !packageCommentsOK && nonTestOrMainFiles > 0 {
 		ref := styleGuideBase + "#package-comments"
 		p.errorfAt(token.Position{Filename: p.dir}, 0.8, link(ref), category("comments"),
 			"at least one file should have a valid package comment")

--- a/lint.go
+++ b/lint.go
@@ -430,7 +430,6 @@ func (f *file) lintPackageComment(reportErrors bool) bool {
 	}
 
 	if f.f.Doc == nil {
-		// f.errorf(f.f, 0.2, link(ref), category("comments"), "should have a package comment, unless it's in another file for this package")
 		return false
 	}
 	ok := true

--- a/testdata/pkg-doc1.go
+++ b/testdata/pkg-doc1.go
@@ -1,3 +1,4 @@
+// MATCH:0 /at least one file should have a valid package comment/
 // Test of missing package comment.
 
-package foo // MATCH /should.*package comment.*unless/
+package foo

--- a/testdata/pkg-doc2.go
+++ b/testdata/pkg-doc2.go
@@ -1,3 +1,4 @@
+// MATCH:0 /at least one file should have a valid package comment/
 // Test of package comment in an incorrect form.
 
 // Some random package doc that isn't in the right form.

--- a/testdata/pkg-doc4.go
+++ b/testdata/pkg-doc4.go
@@ -1,3 +1,4 @@
+// MATCH:0 /at least one file should have a valid package comment/
 // Test of block package comment with leading space.
 
 /*

--- a/testdata/pkg-doc5.go
+++ b/testdata/pkg-doc5.go
@@ -1,3 +1,4 @@
+// MATCH:0 /at least one file should have a valid package comment/
 // Test of detached package comment.
 
 /*
@@ -6,4 +7,4 @@ Package foo is pretty sweet.
 
 package foo
 
-// MATCH:6 /package comment.*detached/
+// MATCH:7 /package comment.*detached/


### PR DESCRIPTION
Fixes golang/lint#381

This change analyses all files in the package upfront. It reports a
single error if no valid package comment was found and at least one
non-test file is present.

Malformed package comments will still produce per-file errors, whether
the missing package comment error is generated or not.

Because this largely eliminates false positives, the confidence has been
bumped to golint's default value of 0.8.