### PR TITLE
lint: swap IfStmt tests to not skip every other IfStmt in a chain

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1045,11 +1045,11 @@ func (f *file) lintElses() {
 		if !ok || ifStmt.Else == nil {
 			return true
 		}
-		if ignore[ifStmt] {
-			return true
-		}
 		if elseif, ok := ifStmt.Else.(*ast.IfStmt); ok {
 			ignore[elseif] = true
+			return true
+		}
+		if ignore[ifStmt] {
 			return true
 		}
 		if _, ok := ifStmt.Else.(*ast.BlockStmt); !ok {

--- a/testdata/else-multi.go
+++ b/testdata/else-multi.go
@@ -16,3 +16,31 @@ func f(x int) bool {
 	}
 	return false
 }
+
+func g(x int) int {
+	if x == 0 {
+		log.Print("x is zero")
+	} else if x > 9 {
+		return 2
+	} else if x > 0 {
+		return 1
+	} else {
+		log.Printf("non-positive x: %d", x)
+	}
+	return 0
+}
+
+func h(x int) int {
+	if x == 0 {
+		log.Print("x is zero")
+	} else if x > 99 {
+		return 3
+	} else if x > 9 {
+		return 2
+	} else if x > 0 {
+		return 1
+	} else {
+		log.Printf("non-positive x: %d", x)
+	}
+	return 0
+}


### PR DESCRIPTION
Fixes golang/lint#382

The fix works by moving the test for ignored nodes after the else-node check.