### PR TITLE
Add import path checking for now hosted on golang.org/x/lint

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -5,7 +5,7 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // golint lints the Go source files named on its command line.
-package main
+package main // import "golang.org/x/lint/golint"
 
 import (
 	"flag"

--- a/lint.go
+++ b/lint.go
@@ -5,7 +5,7 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // Package lint contains a linter for Go source code.
-package lint
+package lint // import "golang.org/x/lint"
 
 import (
 	"bufio"


### PR DESCRIPTION
Add `import path checking` for now hosted on `golang.org/x/lint`.

ref: https://golang.org/cmd/go/#hdr-Import_path_checking