### PR TITLE
lint: allow multiple error return values

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/ast/astutil"
-
 	"golang.org/x/tools/go/gcexportdata"
 )
 
@@ -1693,7 +1692,7 @@ func (f *file) srcLineWithMatch(node ast.Node, pattern string) (m []string) {
 	return rx.FindStringSubmatch(line)
 }
 
-// imports returns true if the current file imports the specified package path
+// imports returns true if the current file imports the specified package path.
 func (f *file) imports(importPath string) bool {
 	all := astutil.Imports(f.fset, f.f)
 	for _, p := range all {

--- a/lint.go
+++ b/lint.go
@@ -23,6 +23,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"golang.org/x/tools/go/ast/astutil"
+
 	"golang.org/x/tools/go/gcexportdata"
 )
 
@@ -1115,6 +1117,9 @@ func (f *file) lintErrorf() {
 		if !isErrorsNew && !isTestingError {
 			return true
 		}
+		if !f.imports("errors") {
+			return true
+		}
 		arg := ce.Args[0]
 		ce, ok = arg.(*ast.CallExpr)
 		if !ok || !isPkgDot(ce.Fun, "fmt", "Sprintf") {
@@ -1686,6 +1691,21 @@ func (f *file) srcLineWithMatch(node ast.Node, pattern string) (m []string) {
 	line = strings.TrimSuffix(line, "\n")
 	rx := regexp.MustCompile(pattern)
 	return rx.FindStringSubmatch(line)
+}
+
+// imports returns true if the current file imports the specified package path
+func (f *file) imports(importPath string) bool {
+	all := astutil.Imports(f.fset, f.f)
+	for _, p := range all {
+		for _, i := range p {
+			uq, err := strconv.Unquote(i.Path.Value)
+			if err == nil && importPath == uq {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // srcLine returns the complete line at p, including the terminating newline.

--- a/lint.go
+++ b/lint.go
@@ -1703,7 +1703,6 @@ func (f *file) imports(importPath string) bool {
 			}
 		}
 	}
-
 	return false
 }
 

--- a/lint.go
+++ b/lint.go
@@ -1310,6 +1310,9 @@ func (f *file) lintErrorReturn() {
 		if len(ret) <= 1 {
 			return true
 		}
+		if isIdent(ret[len(ret)-1].Type, "error") {
+			return true
+		}
 		// An error return parameter should be the last parameter.
 		// Flag any error parameters found before the last.
 		for _, r := range ret[:len(ret)-1] {

--- a/testdata/error-return.go
+++ b/testdata/error-return.go
@@ -41,3 +41,13 @@ func l() (int, error, int) { // MATCH /error should be the last type/
 func m() (x int, err error, y int) { // MATCH /error should be the last type/
 	return 0, nil, 0
 }
+
+// Check for multiple error returns but with errors at the end.
+func n() (int, error, error) { // OK
+	return 0, nil, nil
+}
+
+// Check for multiple error returns mixed in order, but keeping one error at last position.
+func o() (int, error, int, error) { // OK
+	return 0, nil, 0, nil
+}

--- a/testdata/errorf-custom.go
+++ b/testdata/errorf-custom.go
@@ -1,0 +1,25 @@
+// Test for allowed errors.New(fmt.Sprintf()) when a custom errors package is imported.
+
+// Package foo ...
+package foo
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func f(x int) error {
+	if x > 10 {
+		return errors.New(fmt.Sprintf("something %d", x)) // OK
+	}
+	if x > 5 {
+		return errors.New(g("blah")) // OK
+	}
+	if x > 4 {
+		return errors.New("something else") // OK
+	}
+	return nil
+}
+
+func g(s string) string { return "prefix: " + s }


### PR DESCRIPTION
When returning multiple values with an error, 
lint checks if the error is the last return value. 
But the implementation actually is checking for all return values 
except for the last one, and throw the alert if it found an error. 

There is a (edge) case where some function returning more than one error
is getting a false positive even when the last return value is an error. 

This patch adds an early check, to see if the last return value is an error
and if so, it will pass silently. 

Fixes golang/lint#286