### PR TITLE
Fix import path

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/lint"
+	"github.com/golang/lint"
 )
 
 var (


### PR DESCRIPTION
Current path (golang.org/x/lint) is not accessible anymore