### PR TITLE
Update the lint version requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Golint is a linter for Go source code.
 
 ## Installation
 
-Golint requires Go 1.6 or later.
+Golint requires a
+[supported release of Go](https://golang.org/doc/devel/release.html#policy).
 
     go get -u golang.org/x/lint/golint
 


### PR DESCRIPTION
Per the discussion in #400, lint is supported under the same policy as Go itself, and is not supported from a particular version any more.