### PR TITLE
lint: allow *testing.T as first parameter for context parameter check

### DIFF
--- a/testdata/context.go
+++ b/testdata/context.go
@@ -5,6 +5,7 @@ package foo
 
 import (
 	"context"
+	"testing"
 )
 
 // A proper context.Context location
@@ -13,6 +14,10 @@ func x(ctx context.Context) { // ok
 
 // A proper context.Context location
 func x(ctx context.Context, s string) { // ok
+}
+
+// A test helper function with context object allowes context to be not the first argument.
+func x(t *testing.T, ctx context.Context) { // ok
 }
 
 // An invalid context.Context location


### PR DESCRIPTION
Don't fail the linter in case of a test helper function that tests a context object,
even though the context object is not the first parameter.

For example:
```go
func testContext(t *testing.T, ctx context.Context) {
    t.Helper()
    // test ctx...
}
```

Fixes  golang/lint#422