### PR TITLE
use boolean instead of 0 and 1 to indicate where golint is applied and to know whether there are args

### DIFF
--- a/golint/golint.go
+++ b/golint/golint.go
@@ -45,38 +45,38 @@ func main() {
 		// dirsRun, filesRun, and pkgsRun indicate whether golint is applied to
 		// directory, file or package targets. The distinction affects which
 		// checks are run. It is no valid to mix target types.
-		var dirsRun, filesRun, pkgsRun int
+		var dirsRun, filesRun, pkgsRun bool
 		var args []string
 		for _, arg := range flag.Args() {
 			if strings.HasSuffix(arg, "/...") && isDir(arg[:len(arg)-len("/...")]) {
-				dirsRun = 1
+				dirsRun = true
 				for _, dirname := range allPackagesInFS(arg) {
 					args = append(args, dirname)
 				}
 			} else if isDir(arg) {
-				dirsRun = 1
+				dirsRun = true
 				args = append(args, arg)
 			} else if exists(arg) {
-				filesRun = 1
+				filesRun = true
 				args = append(args, arg)
 			} else {
-				pkgsRun = 1
+				pkgsRun = true
 				args = append(args, arg)
 			}
 		}
 
-		if dirsRun+filesRun+pkgsRun != 1 {
+		if !dirsRun && !filesRun && !pkgsRun {
 			usage()
 			os.Exit(2)
 		}
 		switch {
-		case dirsRun == 1:
+		case dirsRun:
 			for _, dir := range args {
 				lintDir(dir)
 			}
-		case filesRun == 1:
+		case filesRun:
 			lintFiles(args...)
-		case pkgsRun == 1:
+		case pkgsRun:
 			for _, pkg := range importPaths(args) {
 				lintPackage(pkg)
 			}

--- a/golint/golint.go
+++ b/golint/golint.go
@@ -65,7 +65,7 @@ func main() {
 			}
 		}
 
-		if !dirsRun && !filesRun && !pkgsRun {
+		if needUsage(dirsRun, filesRun, pkgsRun) {
 			usage()
 			os.Exit(2)
 		}
@@ -97,6 +97,22 @@ func isDir(filename string) bool {
 func exists(filename string) bool {
 	_, err := os.Stat(filename)
 	return err == nil
+}
+
+func needUsage(runs ...bool) bool {
+	need := true
+	for _, run := range runs {
+		if !run {
+			continue
+		}
+
+		if !need {
+			return true
+		}
+		need = false
+	}
+
+	return need
 }
 
 func lintFiles(filenames ...string) {


### PR DESCRIPTION
The type of parameter to indicate where golint is applied and to know whether there are args was `int` or 0 and 1.
But I think that it can be replaced by `bool` and this will make code more legible.

Fixes #432 