### PR TITLE
Improve installation instructions for Go beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Golint requires a
 [supported release of Go](https://golang.org/doc/devel/release.html#policy).
 
     go get -u golang.org/x/lint/golint
+    
+Golint is installed to the folder `$GOPATH/bin` (or if `$GOPATH` is not set: `$HOME/go/bin`). For `golint` to be used globally add this folder to the `$PATH` environment setting.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Golint requires a
 [supported release of Go](https://golang.org/doc/devel/release.html#policy).
 
     go get -u golang.org/x/lint/golint
-    
-Golint is installed to the folder `$GOPATH/bin` (or if `$GOPATH` is not set: `$HOME/go/bin`). For `golint` to be used globally add this folder to the `$PATH` environment setting.
+
+To find out where `golint` was installed you can run `go list -f {{.Target}} golang.org/x/lint/golint`. For `golint` to be used globally add that directory to the `$PATH` environment setting.
 
 ## Usage
 


### PR DESCRIPTION
As a mentor at `exercism.io` I have to explain again and again how to install `golint`. Being new to Go they don't know where `golint` is installed and how to get it to work if they get the error message: `command not found`.