### PR TITLE
Add `GID` to commonInitialisms

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -776,6 +776,7 @@ var commonInitialisms = map[string]bool{
 	"CSS":   true,
 	"DNS":   true,
 	"EOF":   true,
+	"GID":   true,
 	"GUID":  true,
 	"HTML":  true,
 	"HTTP":  true,


### PR DESCRIPTION
Group IDs are mostly abbreviates as `GID`, so we should add them
to the mappings as well.