### PR TITLE
modify indent-error-flow message for clarity

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -1014,7 +1014,7 @@ func (f *file) lintElses() {
 			if shortDecl {
 				extra = " (move short variable declaration to its own line if necessary)"
 			}
-			f.errorf(ifStmt.Else, 1, link(styleGuideBase+"#indent-error-flow"), category("indent"), "if block ends with a return statement, so drop this else and outdent its block"+extra)
+			f.errorf(ifStmt.Else, 1, link(styleGuideBase+"#indent-error-flow"), category("indent"), "'if' block ends with a return statement, so drop the 'else' keyword and outdent its block"+extra)
 		}
 		return true
 	})


### PR DESCRIPTION
PR modifies the message for indent-error-flow to avoid confusion between the Go language keywords and English words.

brief related Slack discussion: https://gophers.slack.com/archives/C0VPK4Z5E/p1568808654032200

@bcmills 