### PR TITLE
go/lint: add Flush and Close to commonMethods

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -836,9 +836,11 @@ func (f *file) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 var commonMethods = map[string]bool{
 	"Error":     true,
 	"Read":      true,
+	"Write":     true,
 	"ServeHTTP": true,
 	"String":    true,
-	"Write":     true,
+	"Flush":     true,
+	"Close":     true,
 }
 
 // lintFuncDoc examines doc comments on functions and methods.

--- a/lint.go
+++ b/lint.go
@@ -834,13 +834,13 @@ func (f *file) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 }
 
 var commonMethods = map[string]bool{
+	"Close":     true,
 	"Error":     true,
+	"Flush":     true,
 	"Read":      true,
-	"Write":     true,
 	"ServeHTTP": true,
 	"String":    true,
-	"Flush":     true,
-	"Close":     true,
+	"Write":     true,
 }
 
 // lintFuncDoc examines doc comments on functions and methods.

--- a/testdata/common-methods.go
+++ b/testdata/common-methods.go
@@ -9,7 +9,9 @@ import "net/http"
 // T is ...
 type T int
 
+func (T) Close()                                           {}
 func (T) Error() string                                    { return "" }
+func (T) Flush()                                           {}
 func (T) String() string                                   { return "" }
 func (T) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 func (T) Read(p []byte) (n int, err error)                 { return 0, nil }

--- a/testdata/common-methods.go
+++ b/testdata/common-methods.go
@@ -9,9 +9,9 @@ import "net/http"
 // T is ...
 type T int
 
-func (T) Close()                                           {}
+func (T) Close() error                                     { return nil }
 func (T) Error() string                                    { return "" }
-func (T) Flush()                                           {}
+func (T) Flush() error                                     { return nil }
 func (T) String() string                                   { return "" }
 func (T) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 func (T) Read(p []byte) (n int, err error)                 { return 0, nil }


### PR DESCRIPTION
according to https://golang.org/doc/effective_go.html#interface-names
The `Flush` and `Close` also have canonical signatures and meanings, but they are not in commonMethods for now.