### PR TITLE
Adding CI for PPC64LE arch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ script:
   - go test -v -race ./...
 
 matrix:
+  include:
+    - arch: ppc64le
+      go: 1.14.x
+    - arch: ppc64le
+      go: master
   allow_failures:
     - go: master
   fast_finish: true


### PR DESCRIPTION
Hi,

I have enabled CI on PPC64LE architecture for 1.14.x . Older version are not well supported. Please review.

Thanks