### PR TITLE
Switch to a more inclusive language

### DIFF
--- a/testdata/repetition.go
+++ b/testdata/repetition.go
@@ -1,13 +1,13 @@
-// Test of stuttery names.
+// Test of repetetive names.
 
 // Package donut ...
 package donut
 
 // DonutMaker makes donuts.
-type DonutMaker struct{} // MATCH /donut\.DonutMaker.*stutter/
+type DonutMaker struct{} // MATCH /donut\.DonutMaker.*repetitive/
 
 // DonutRank computes the ranking of a donut.
-func DonutRank(d Donut) int { // MATCH /donut\.DonutRank.*stutter/
+func DonutRank(d Donut) int { // MATCH /donut\.DonutRank.*repetitive/
 	return 0
 }
 


### PR DESCRIPTION
This commit changes various parts in the code that feel
very odd for someone who actually stutters. We are linting
for something bad and considering it as harmful. So let's
switch to a wording that is more technical and less
"high school yard"-like.