### PR TITLE
lint: fix spelling of constrained

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -666,7 +666,7 @@ func (f *file) lintNames() {
 			}
 		case *ast.InterfaceType:
 			// Do not check interface method names.
-			// They are often constrainted by the method names of concrete types.
+			// They are often constrained by the method names of concrete types.
 			for _, x := range v.Methods.List {
 				ft, ok := x.Type.(*ast.FuncType)
 				if !ok { // might be an embedded interface name


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/lint/commit/4894a4f1f198ba3cdeac0e098d772c996802493f#commitcomment-49536803

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/lint/commit/dbcb559b7ef4f09b22628dad5eedc9c48b2500fb