### PR TITLE
lint: do not suggest keywords as Go names

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -551,6 +551,11 @@ func isInTopLevel(f *ast.File, ident *ast.Ident) bool {
 	return true
 }
 
+// isGoKeyword returns true if "name" is a reserved keyword.
+func isGoKeyword(name string) bool {
+	return keywords[name]
+}
+
 // lintNames examines all names in the file.
 // It complains if any use underscores or incorrect known initialisms.
 func (f *file) lintNames() {
@@ -596,6 +601,9 @@ func (f *file) lintNames() {
 		}
 
 		if len(id.Name) > 2 && strings.Contains(id.Name[1:], "_") {
+			if isGoKeyword(should) {
+				return // refrain from suggesting the use of a keyword as a valid name.
+			}
 			f.errorf(id, 0.9, link("http://golang.org/doc/effective_go.html#mixed-caps"), category("naming"), "don't use underscores in Go names; %s %s should be %s", thing, id.Name, should)
 			return
 		}
@@ -694,6 +702,36 @@ func (f *file) lintNames() {
 		}
 		return true
 	})
+}
+
+// keywords is the set of Go language keywords.
+// see https://golang.org/ref/spec#Keywords
+var keywords = map[string]bool{
+	"break":       true,
+	"default":     true,
+	"func":        true,
+	"interface":   true,
+	"select":      true,
+	"case":        true,
+	"defer":       true,
+	"go":          true,
+	"map":         true,
+	"struct":      true,
+	"chan":        true,
+	"else":        true,
+	"goto":        true,
+	"package":     true,
+	"switch":      true,
+	"const":       true,
+	"fallthrough": true,
+	"if":          true,
+	"range":       true,
+	"type":        true,
+	"continue":    true,
+	"for":         true,
+	"import":      true,
+	"return":      true,
+	"var":         true,
 }
 
 // lintName returns a different name if it should be different.

--- a/lint_test.go
+++ b/lint_test.go
@@ -252,6 +252,23 @@ func TestLintName(t *testing.T) {
 	}
 }
 
+func TestKeyword(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"type", true},
+		{"goto", true},
+		{"while", false},
+	}
+	for _, test := range tests {
+		got := isGoKeyword(test.name)
+		if got != test.want {
+			t.Errorf("isGoKeyword(%q) = %t, want %t", test.name, got, test.want)
+		}
+	}
+}
+
 func TestExportedType(t *testing.T) {
 	tests := []struct {
 		typString string


### PR DESCRIPTION
In some circumstances, programmers are tempted to use Go reserved
keywords as names (e.g. "type" or "default"). As this is forbidden
in Go, the compiler will reject it. A common workaround is to append
an underline to the keyword to make the compiler happy, e.g.,
changing the name "type" to "type_".

Previously golint considered that use of underline bad style and
wrongly suggested employing the original keyword instead:

astVarRef.go:6:2: don't use underscores in Go names; struct field type_ should be type
cmdIf.go:32:3: don't use underscores in Go names; var goto_ should be goto

This CL changes golint so that it doesn't make that invalid suggestion.

Fixes golang/lint#393

---
closes #394; closes #464

---


Note: I did not write any of the code. I've squashed the two commits from #464 together and rewritten the commit message.

GitHub hasn't seen @jucie since 2019.

I'm willing to put some effort into this PR (including changing code if requested) as I regularly run into this while touching random repositories. (My current instance was for `default`, but I've definitely hit `type` and I think some others, probably `chan`.)