### PR TITLE
lint: comment on exported example improve

### DIFF
--- a/lint.go
+++ b/lint.go
@@ -829,7 +829,7 @@ func (f *file) lintTypeDoc(t *ast.TypeSpec, doc *ast.CommentGroup) {
 		}
 	}
 	if !strings.HasPrefix(s, t.Name.Name+" ") {
-		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported type %v should be of the form "%v ..." (with optional leading article)`, t.Name, t.Name)
+		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported type %v should be of the form "// %v ..." (with optional leading article)`, t.Name, t.Name)
 	}
 }
 
@@ -878,7 +878,7 @@ func (f *file) lintFuncDoc(fn *ast.FuncDecl) {
 	s := fn.Doc.Text()
 	prefix := fn.Name.Name + " "
 	if !strings.HasPrefix(s, prefix) {
-		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "%s..."`, kind, name, prefix)
+		f.errorf(fn.Doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "// %s..."`, kind, name, prefix)
 	}
 }
 
@@ -931,7 +931,7 @@ func (f *file) lintValueSpecDoc(vs *ast.ValueSpec, gd *ast.GenDecl, genDeclMissi
 	}
 	prefix := name + " "
 	if !strings.HasPrefix(doc.Text(), prefix) {
-		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "%s..."`, kind, name, prefix)
+		f.errorf(doc, 1, link(docCommentsLink), category("comments"), `comment on exported %s %s should be of the form "// %s..."`, kind, name, prefix)
 	}
 }
 

--- a/testdata/4.go
+++ b/testdata/4.go
@@ -10,11 +10,11 @@ type T int // MATCH /exported type T.*should.*comment.*or.*unexport/
 func (T) F() {} // MATCH /exported method T\.F.*should.*comment.*or.*unexport/
 
 // this is a nice type.
-// MATCH /comment.*exported type U.*should.*form.*"U ..."/
+// MATCH /comment.*exported type U.*should.*form.*"// U ..."/
 type U string
 
 // this is a neat function.
-// MATCH /comment.*exported method U\.G.*should.*form.*"G ..."/
+// MATCH /comment.*exported method U\.G.*should.*form.*"// G ..."/
 func (U) G() {}
 
 // A V is a string.
@@ -34,5 +34,5 @@ var Y, Z int // MATCH /exported var Z.*own declaration/
 var Location, _ = time.LoadLocation("Europe/Istanbul") // not Constantinople
 
 // this is improperly documented
-// MATCH /comment.*const.*Thing.*form.*"Thing ..."/
+// MATCH /comment.*const.*Thing.*form.*"// Thing ..."/
 const Thing = "wonderful"


### PR DESCRIPTION
golint expects comments of form `// X ...`, but the message omits the
`//`, so users may think that a C++ multi-line comment like `/* X ...`
is acceptable.

Tweak the output to direct users to the expected format.

Closes: https://github.com/golang/lint/pull/517
Closes: https://github.com/golang/lint/issues/488
Signed-off-by: Robin H. Johnson <robbat2@orbis-terrarum.net>
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>